### PR TITLE
issues #14 #35 #36 #37

### DIFF
--- a/src/main/resources/biocache-config.properties
+++ b/src/main/resources/biocache-config.properties
@@ -129,3 +129,9 @@ collection.contacts.url=http://collections.ala.org.au/ws/collection
 
 # BVP config
 volunteer.hub.uid=dh6
+
+# Define additional fields to index. These fields are imported from CSVs and must have a match in schema.xml
+#additional.fields.to.index=custom_field_1_s,custom_field_2_i
+
+# Setting this path will export SOLR docs to a CSV during indexing
+#export.index.as.csv.path=/tmp/

--- a/src/main/scala/au/org/ala/biocache/Config.scala
+++ b/src/main/scala/au/org/ala/biocache/Config.scala
@@ -199,6 +199,10 @@ object Config {
     }
     properties
   }
+
+  val additionalFieldsToIndex = configModule.properties.getProperty("additional.fields.to.index", "").split(",").toList
+
+  val exportIndexAsCsvPath = configModule.properties.getProperty("export.index.as.csv.path", "")
 }
 
 /**

--- a/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAOImpl.scala
+++ b/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAOImpl.scala
@@ -862,7 +862,9 @@ class OccurrenceDAOImpl extends OccurrenceDAO {
     if(map.isEmpty){
       logger.debug("Unable to reindex : " + rowKey)
     } else {
-      indexDAO.indexFromMap(rowKey, map.get, batch=false)
+      var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexDAO.getCsvWriter } else { null }
+      indexDAO.indexFromMap(rowKey, map.get, batch=false, csvFileWriter = csvFileWriter)
+      if (csvFileWriter != null) { csvFileWriter.flush(); csvFileWriter.close() }
     }
   }
   /**

--- a/src/main/scala/au/org/ala/biocache/index/IndexDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexDAO.scala
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable.ArrayBuffer
 import java.util.Date
 import org.apache.commons.lang.time.DateFormatUtils
-import java.io.OutputStream
+import java.io.{File, FileWriter, OutputStream}
 import scala.util.parsing.json.JSON
 import au.org.ala.biocache.processor.Processors
 import au.org.ala.biocache.dao.OccurrenceDAO
@@ -53,7 +53,8 @@ trait IndexDAO {
                    commit: Boolean = false,
                    miscIndexProperties: Seq[String] = Array[String](),
                    test:Boolean = false,
-                   batchID:String = "")
+                   batchID:String = "",
+                   csvFileWriter:FileWriter = null)
 
   /**
    * Truncate the current index
@@ -109,16 +110,33 @@ trait IndexDAO {
   }
 
   /**
+   * Returns a lat,long string expression formatted to the supplied Double format and step size.
+   *
+   * e.g. 0.02 step size
+   *
+   */
+  def getLatLongStringStep(lat: Double, lon: Double, format: String, step: Double): String = {
+    if (!lat.isNaN && !lon.isNaN) {
+      val df = new java.text.DecimalFormat(format)
+      //By some "strange" decision the default rounding model is HALF_EVEN
+      df.setRoundingMode(java.math.RoundingMode.HALF_UP)
+      df.format(Math.round(lat / step) * step) + "," + df.format(Math.round(lon / step) * step)
+    } else {
+      ""
+    }
+  }
+
+  /**
    * The header values for the CSV file.
    */
-  val header = List("id", "row_key", "occurrence_id", "data_hub_uid", "data_hub", "data_provider_uid", "data_provider", "data_resource_uid",
+  lazy val header = List("id", "row_key", "occurrence_id", "data_hub_uid", "data_hub", "data_provider_uid", "data_provider", "data_resource_uid",
     "data_resource", "institution_uid", "institution_code", "institution_name",
     "collection_uid", "collection_code", "collection_name", "catalogue_number",
     "taxon_concept_lsid", "occurrence_date", "occurrence_year", "taxon_name", "common_name", "names_and_lsid", "common_name_and_lsid",
     "rank", "rank_id", "raw_taxon_name", "raw_common_name", "multimedia", "image_url", "all_image_url",
     "species_group", "country_code", "country", "lft", "rgt", "kingdom", "phylum", "class", "order",
     "family", "genus", "genus_guid", "species", "species_guid", "state", "imcra", "ibra", "places", "latitude", "longitude",
-    "lat_long", "point-1", "point-0.1", "point-0.01", "point-0.001", "point-0.0001",
+    "lat_long", "point-1", "point-0.1", "point-0.01", "point-0.02", "point-0.001", "point-0.0001",
     "year", "month", "basis_of_record", "raw_basis_of_record", "type_status",
     "raw_type_status", "taxonomic_kosher", "geospatial_kosher",  "location_remarks",
     "occurrence_remarks", "user_assertions", "collector", "state_conservation", "raw_state_conservation",
@@ -130,7 +148,7 @@ trait IndexDAO {
     "duplicate_type", "sensitive_coordinate_uncertainty", "distance_outside_expert_range", "elevation_d", "min_elevation_d", "max_elevation_d",
     "depth_d", "min_depth_d", "max_depth_d", "name_parse_type_s","occurrence_status_s", "occurrence_details", "photographer_s", "rights",
     "raw_geo_validation_status_s", "raw_occurrence_status_s", "raw_locality","raw_latitude","raw_longitude","raw_datum","raw_sex",
-    "sensitive_locality")
+    "sensitive_locality") ::: Config.additionalFieldsToIndex
 
   /**
    * Constructs a scientific name.
@@ -405,6 +423,7 @@ trait IndexDAO {
           getLatLongString(lat, lon, "#"),
           getLatLongString(lat, lon, "#.#"),
           getLatLongString(lat, lon, "#.##"),
+          getLatLongStringStep(lat, lon, "#.##", 0.02),
           getLatLongString(lat, lon, "#.###"),
           getLatLongString(lat, lon, "#.####"),
           getValue("year.p", map),
@@ -483,13 +502,21 @@ trait IndexDAO {
           map.getOrElse("geodeticDatum",""),
           map.getOrElse("sex",""),
           sensitiveMap.getOrElse("locality", "")
-        )
+        ) ::: Config.additionalFieldsToIndex.map(field => map.getOrElse(field, ""))
       } else {
         return List()
       }
     } catch {
       case e: Exception => logger.error(e.getMessage, e); throw e
     }
+  }
+
+  def getCsvWriter = {
+    var fw : FileWriter = null
+    if (Config.exportIndexAsCsvPath != null && Config.exportIndexAsCsvPath.length > 0) {
+      fw = new FileWriter(File.createTempFile("index.", "." + System.currentTimeMillis() + ".csv", new File(Config.exportIndexAsCsvPath)))
+    }
+    fw
   }
 }
 

--- a/src/main/scala/au/org/ala/biocache/index/IndexRecordMultiThreaded.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexRecordMultiThreaded.scala
@@ -439,6 +439,7 @@ class IndexRunner(centralCounter: Counter, threadId: Int, startKey: String, endK
     var startTime = System.currentTimeMillis
     var finishTime = System.currentTimeMillis
     var check = true
+    var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexer.getCsvWriter } else { null }
 
     //page through and create and index for this range
     Config.persistenceManager.pageOverAll("occ", (guid, map) => {
@@ -450,10 +451,10 @@ class IndexRunner(centralCounter: Counter, threadId: Int, startKey: String, endK
           check = false
           //dont index the start key - ranges will exclude the start key but include the endKey
           if (!guid.equals(startKey)) {
-            indexer.indexFromMap(guid, map, commit = commit, batchID = threadId.toString)
+            indexer.indexFromMap(guid, map, commit = commit, batchID = threadId.toString, csvFileWriter = csvFileWriter)
           }
         } else {
-          indexer.indexFromMap(guid, map, commit = commit, batchID = threadId.toString)
+          indexer.indexFromMap(guid, map, commit = commit, batchID = threadId.toString, csvFileWriter = csvFileWriter)
         }
       } catch {
         case e:Exception => logger.error("Problem indexing record: " + guid + ""  + e.getMessage())
@@ -470,6 +471,8 @@ class IndexRunner(centralCounter: Counter, threadId: Int, startKey: String, endK
     }, startKey, endKey, pageSize = pageSize)
 
     indexer.finaliseIndex(true, true)
+
+    if (csvFileWriter != null) { csvFileWriter.flush(); csvFileWriter.close() }
 
     finishTime = System.currentTimeMillis
     logger.info("Total indexing time for this thread " + ((finishTime - start).toFloat) / 60000f + " minutes.")

--- a/src/main/scala/au/org/ala/biocache/index/IndexRecords.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexRecords.scala
@@ -2,14 +2,14 @@ package au.org.ala.biocache.index
 
 import org.slf4j.LoggerFactory
 import au.org.ala.biocache._
-import java.io.File
+import java.io.{FileWriter, File}
 import java.util.Date
 import java.util.concurrent.ArrayBlockingQueue
 import au.org.ala.biocache.dao.OccurrenceDAO
 import au.org.ala.biocache.parser.DateParser
 import au.org.ala.biocache.load.FullRecordMapper
 import au.org.ala.biocache.persistence.PersistenceManager
-import au.org.ala.biocache.util.{FileHelper, StringConsumer, OptionParser}
+import au.org.ala.biocache.util.{StringFileWriterConsumer, FileHelper, StringConsumer, OptionParser}
 import au.org.ala.biocache.cmd.{IncrementalTool, NoArgsTool, Tool}
 
 /**
@@ -172,11 +172,12 @@ object IndexRecords extends Tool with IncrementalTool {
     val start = System.currentTimeMillis
     var startTime = System.currentTimeMillis
     var finishTime = System.currentTimeMillis
+    var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexer.getCsvWriter } else { null }
     performPaging( (guid, map) => {
       counter += 1
       ///convert EL and CL properties at this stage
       val shouldcommit = counter % 10000 == 0
-      indexer.indexFromMap(guid, map, startDate=startDate, commit=shouldcommit, miscIndexProperties=miscIndexProperties, test=test)
+      indexer.indexFromMap(guid, map, startDate=startDate, commit=shouldcommit, miscIndexProperties=miscIndexProperties, test=test, csvFileWriter = csvFileWriter)
       if (counter % pageSize == 0) {
         if(callback !=null) {
           callback.progressMessage(counter)
@@ -188,6 +189,8 @@ object IndexRecords extends Tool with IncrementalTool {
       }
       true
     }, startUuid, endUuid, checkDeleted = checkDeleted, pageSize = pageSize)
+
+    if (csvFileWriter != null) { csvFileWriter.flush(); csvFileWriter.close() }
 
     finishTime = System.currentTimeMillis
     logger.info("Total indexing time " + ((finishTime-start).toFloat)/1000f + " seconds")
@@ -222,17 +225,19 @@ object IndexRecords extends Tool with IncrementalTool {
     var counter = 0
     var startTime = System.currentTimeMillis
     var finishTime = System.currentTimeMillis
+    var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexer.getCsvWriter } else { null }
     rowKeys.foreach(rowKey=>{
       counter += 1
       val map = persistenceManager.get(rowKey, "occ")
       val shouldcommit = counter % 10000 == 0
-      if (!map.isEmpty) indexer.indexFromMap(rowKey, map.get, commit=shouldcommit)
+      if (!map.isEmpty) indexer.indexFromMap(rowKey, map.get, commit=shouldcommit, csvFileWriter = csvFileWriter)
       if (counter % 100 == 0) {
         finishTime = System.currentTimeMillis
         logger.debug(counter + " >> Last key : " + rowKey + ", records per sec: " + 100f / (((finishTime - startTime).toFloat) / 1000f))
         startTime = System.currentTimeMillis
       }
     })
+    if (csvFileWriter != null) { csvFileWriter.flush(); csvFileWriter.close() }
     indexer.finaliseIndex(false, false)  //commit but don't optimise or shutdown
   }
 
@@ -245,17 +250,20 @@ object IndexRecords extends Tool with IncrementalTool {
   def indexListThreaded(rowKeys: File, threads: Int) {
     val queue = new ArrayBlockingQueue[String](100)
     var ids = 0
-    val pool: Array[StringConsumer] = Array.fill(threads) {
+    val csvFileWriterList : Array[FileWriter] = Array[FileWriter]()
+    val pool: Array[StringFileWriterConsumer] = Array.fill(threads) {
       var counter = 0
       var startTime = System.currentTimeMillis
       var finishTime = System.currentTimeMillis
+      var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexer.getCsvWriter } else { null }
+      csvFileWriterList :+ csvFileWriter
       indexer.init
-      val p = new StringConsumer(queue, ids, { rowKey =>
+      val p = new StringFileWriterConsumer(queue, ids, csvFileWriter, { (rowKey, csvFileWriter) =>
         counter += 1
         val map = persistenceManager.get(rowKey, "occ")
         val shouldcommit = counter % 1000 == 0
         if (!map.isEmpty) {
-          indexer.indexFromMap(rowKey, map.get, commit = shouldcommit)
+          indexer.indexFromMap(rowKey, map.get, commit = shouldcommit, csvFileWriter = csvFileWriter)
         }
         //debug counter
         if (counter % 1000 == 0) {
@@ -275,6 +283,12 @@ object IndexRecords extends Tool with IncrementalTool {
     pool.foreach(t => t.shouldStop = true)
     pool.foreach(_.join)
     indexer.finaliseIndex(false, false)
+
+    csvFileWriterList.foreach( t =>
+      if ( t != null ) {
+        t.flush()
+        t.close()
+      } )
   }
 
   /**
@@ -285,19 +299,21 @@ object IndexRecords extends Tool with IncrementalTool {
     var counter = 0
     var startTime = System.currentTimeMillis
     var finishTime = System.currentTimeMillis
+    var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexer.getCsvWriter } else { null }
 
     file.foreachLine(line => {
       counter += 1
       val rowKey = if (line.head == '"' && line.last == '"') line.substring(1,line.length-1) else line
       val map = persistenceManager.get(rowKey, "occ")
       val shouldCommit = counter % 10000 == 0
-      if (!map.isEmpty) indexer.indexFromMap(rowKey, map.get, commit=shouldCommit)
+      if (!map.isEmpty) indexer.indexFromMap(rowKey, map.get, commit=shouldCommit, csvFileWriter = csvFileWriter)
       if (counter % 1000 == 0) {
         finishTime = System.currentTimeMillis
         logger.info(counter + " >> Last key : " + line + ", records per sec: " + 1000f / (((finishTime - startTime).toFloat) / 1000f))
         startTime = System.currentTimeMillis
       }
     })
+    if (csvFileWriter != null) { csvFileWriter.flush(); csvFileWriter.close() }
     indexer.finaliseIndex(false, shutdown)
   }
 
@@ -309,6 +325,7 @@ object IndexRecords extends Tool with IncrementalTool {
     var counter = 0
     var startTime = System.currentTimeMillis
     var finishTime = System.currentTimeMillis
+    var csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) { indexer.getCsvWriter } else { null }
 
     file.foreachLine(line => {
       val uuid = line.replaceAll("\"","")
@@ -317,13 +334,14 @@ object IndexRecords extends Tool with IncrementalTool {
       val map = persistenceManager.getByIndex(uuid, "occ", "uuid")
       val shouldCommit = counter % 10000 == 0
 
-      if (!map.isEmpty) indexer.indexFromMap(uuid, map.get, commit=shouldCommit)
+      if (!map.isEmpty) indexer.indexFromMap(uuid, map.get, commit=shouldCommit, csvFileWriter=csvFileWriter)
       if (counter % 1000 == 0) {
         finishTime = System.currentTimeMillis
         logger.info(counter + " >> Last key : " + line + ", records per sec: " + 1000f / (((finishTime - startTime).toFloat) / 1000f))
         startTime = System.currentTimeMillis
       }
     })
+    if (csvFileWriter != null) { csvFileWriter.flush(); csvFileWriter.close() }
 
     logger.info("Finalising index.....")
     indexer.finaliseIndex(false, true)

--- a/src/main/scala/au/org/ala/biocache/util/LayersStore.scala
+++ b/src/main/scala/au/org/ala/biocache/util/LayersStore.scala
@@ -120,6 +120,28 @@ class LayersStore ( layersStoreUrl: String) {
     (fields)
   }
 
+  /*
+  returns map of valid fieldIds for sampling
+  key = fieldId
+  value = display name
+   */
+  def getFieldIdsAndDisplayNames() : util.HashMap[String, String] = {
+    val httpClient = new DefaultHttpClient()
+    val httpGet = new HttpGet(layersStoreUrl + "/fieldsdb")
+    val response = httpClient.execute(httpGet)
+    val result = response.getStatusLine()
+    val responseBody: String = Source.fromInputStream(response.getEntity().getContent()).mkString
+    logger.debug("Response code: " + result.getStatusCode)
+
+    val fields: util.HashMap[String, String] = new util.HashMap[String, String]()
+    val ja: JSONArray = JSONArray.fromObject(responseBody)
+    for (j <- 0 until ja.size()) {
+      fields.put(ja.getJSONObject(j).getString("id"), ja.getJSONObject(j).getString("name"))
+    }
+
+    (fields)
+  }
+
   private def samplingStart(fields:String, points:String) : (String) = {
     val (responseCode, respBody) = HttpUtil.postBody(layersStoreUrl + "/intersect/batch", "application/json", "fids=" + fields + "&points=" + points)
 

--- a/src/main/scala/au/org/ala/biocache/util/StringFileWriterConsumer.scala
+++ b/src/main/scala/au/org/ala/biocache/util/StringFileWriterConsumer.scala
@@ -1,0 +1,32 @@
+package au.org.ala.biocache.util
+
+import java.io.FileWriter
+import java.util.concurrent.BlockingQueue
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A generic threaded consumer that takes a string and FileWriter and calls the supplied proc
+ */
+class StringFileWriterConsumer(q: BlockingQueue[String], id: Int, csvFileWriter: FileWriter, proc: (String, FileWriter) => Unit) extends Thread {
+
+  protected val logger = LoggerFactory.getLogger("StringFileWriterConsumer")
+
+  var shouldStop = false
+
+  override def run() {
+    while (!shouldStop || q.size() > 0) {
+      try {
+        //wait 1 second before assuming that the queue is empty
+        val guid = q.poll(1, java.util.concurrent.TimeUnit.SECONDS)
+        if (guid != null) {
+          logger.debug("Guid Consumer " + id + " is handling " + guid)
+          proc(guid, csvFileWriter)
+        }
+      } catch {
+        case e: Exception => e.printStackTrace()
+      }
+    }
+    logger.debug("Stopping " + id)
+  }
+}


### PR DESCRIPTION
Add index on point-0.02

Add config parameter additional.fields.to.index to define additional imported CSV fields to index

Add config parameter export.index.as.csv.path for optional export during all indexing. One CSV created for each indexing thread. Filenames are "index_randomNumber_timestamp.csv"

Add header to export-stream

Add export-stream option -qa to include assertions in the export. After using -qa it won't return to the default false if omitted. (Tools not resetting options to defaults)