### PR TITLE
Pipeline delimited recordedBy values fixed.

### DIFF
--- a/src/main/scala/au/org/ala/biocache/load/DwcCSVLoader.scala
+++ b/src/main/scala/au/org/ala/biocache/load/DwcCSVLoader.scala
@@ -129,7 +129,7 @@ class DwcCSVLoader extends DataLoader {
       if (separatorString == "\\t") '\t'
       else separatorString.toCharArray.head
     }
-    val escape = params.getOrElse("csv_escape_char","|").head
+    val escape = params.getOrElse("csv_escape_char","\\").head
     val reader = new CSVReader(new InputStreamReader(new org.apache.commons.io.input.BOMInputStream(new FileInputStream(file))), separator, quotechar, escape)
 
     logger.info("Using CSV reader with the following settings quotes: " + quotechar + " separator: " + separator + " escape: " + escape)

--- a/src/main/scala/au/org/ala/biocache/parser/CollectorNameParser.scala
+++ b/src/main/scala/au/org/ala/biocache/parser/CollectorNameParser.scala
@@ -23,7 +23,7 @@ object CollectorNameParser {
   val SINGLE_NAME_PATTERN = ("(?:(?:" + titles + ")(?:[. ]|$))?([\\p{Lu}\\p{Ll}']*)").r
   val ORGANISATION_PATTERN = ("((?:.*?)?(?:" + ORGANISATION_WORDS + ")(?:.*)?)").r
   val AND = "AND|and|And|&"
-  val COLLECTOR_DELIM = ";|\"\"| - ".r;
+  val COLLECTOR_DELIM = ";|\"\"|\\|| - ".r;
   val COMMA_LIST = ",|&".r
   val suffixes = "jr|Jr|JR"
   val AND_NAME_LISTPattern = ("((?:[A-Z][. ] ?){0,3})([" + NAME_LETTERS + "][\\p{Ll}-']*)? ?([" + NAME_LETTERS + "][\\p{Ll}\\p{Lu}'-]*)? ?" + "(?:" + AND + ") ?((?:[A-Z][. ] ?){0,3})([" + NAME_LETTERS + "][\\p{Ll}'-]*)? ?([" + NAME_LETTERS + "][\\p{Ll}\\p{Lu}'-]*)?").r


### PR DESCRIPTION
Changed the default CSV escaping character from | to \ as it was causing parsing issues before, also the pipe character is introduced to be a field separator for multi value properties. 
Here is the test record:  http://biocache.ala.org.au/occurrences/2cf323ab-b23d-4158-a76e-910eeb5179a3 