### PR TITLE
Speed up sample and sandbox loading changes

### DIFF
--- a/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAO.scala
@@ -62,6 +62,8 @@ trait OccurrenceDAO extends DAO {
 
   def updateOccurrence(rowKey: String, oldRecord: FullRecord, updatedRecord: FullRecord, assertions: Option[Map[String,Array[QualityAssertion]]], version: Version)
 
+  def updateOccurrenceBatch(batches: List[Map[String, Object]])
+
   def updateOccurrence(rowKey: String, anObject: AnyRef, version: Version): Unit
 
   def addSystemAssertion(rowKey: String, qualityAssertion: QualityAssertion, replaceExistCode:Boolean=false, checkExisting:Boolean=true): Unit

--- a/src/main/scala/au/org/ala/biocache/index/IndexRecordMultiThreaded.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexRecordMultiThreaded.scala
@@ -67,15 +67,17 @@ trait RangeCalculator {
           .getOrElse("facetResults", List[Map[String, Object]]())
           .asInstanceOf[List[Map[String, Object]]]
 
-        val rowKey = facetResults.head.get("fieldResult").get.asInstanceOf[List[Map[String, String]]].head.getOrElse("label", "")
-        logger.info("Retrieved row key: " + rowKey)
+        if (facetResults.size > 0) {
+          val rowKey = facetResults.head.get("fieldResult").get.asInstanceOf[List[Map[String, String]]].head.getOrElse("label", "")
+          logger.info("Retrieved row key: " + rowKey)
 
-        if (i > 0) {
-          buff(i - 1) = (lastKey, rowKey)
+          if (i > 0) {
+            buff(i - 1) = (lastKey, rowKey)
+          }
+          //we want the first key to be ""
+          if (i != 0)
+            lastKey = rowKey
         }
-        //we want the first key to be ""
-        if (i != 0)
-          lastKey = rowKey
       }
 
       buff(buff.length - 1) = (lastKey, end)


### PR DESCRIPTION
This should drop 'sample' time from the current 16hrs to 5hrs. 

Batching commits and adding try/retry to reduce some errors on LoadSamplingRunner. 

Removed offline processor for sandbox record loading. This processor was taking more time than others and it did not look like anything would be missing if excluded from sandbox record loading.





