### PR TITLE
Trim filename for separated values in associatedMedia

### DIFF
--- a/src/main/scala/au/org/ala/biocache/load/DwcCSVLoader.scala
+++ b/src/main/scala/au/org/ala/biocache/load/DwcCSVLoader.scala
@@ -241,8 +241,9 @@ class DwcCSVLoader extends DataLoader {
             if (fr.occurrence.associatedMedia != null){
               //check for full resolvable http paths
               val filesToImport = fr.occurrence.associatedMedia.split(";")
-              val filePathsInStore = filesToImport.map(fileName => {
+              val filePathsInStore = filesToImport.map(name => {
                 //if the file name isnt a HTTP URL construct file absolute file paths
+                val fileName = name.trim();
                 if(!fileName.startsWith("http://") && !fileName.startsWith("https://") && !fileName.startsWith("ftp://")  && !fileName.startsWith("ftps://")  && !fileName.startsWith("file://")){
                   val filePathBuffer = new ArrayBuffer[String]
                   filePathBuffer += "file:///" + file.getParent + File.separator + fileName


### PR DESCRIPTION
so that prefix spaces don't gum up the URL.