### PR TITLE
Handle already stored images/multimedia

### DIFF
--- a/src/main/scala/au/org/ala/biocache/load/DataLoader.scala
+++ b/src/main/scala/au/org/ala/biocache/load/DataLoader.scala
@@ -308,27 +308,20 @@ trait DataLoader {
         }
       }
 
-      val (exists, filename, filePathOrId) = Config.mediaStore.alreadyStored(fr.uuid, dataResourceUid, fileToStore)
-
-      if (exists) {
-        logger.info("Media file already stored: " + filePathOrId)
-        fileNameToID.put(filename, filePathOrId)
-      } else {
-        val savedTo = Config.mediaStore.save(fr.uuid, fr.attribution.dataResourceUid, fileToStore, media)
-        savedTo match {
-          case Some((savedFilename, savedFilePathOrId)) => {
-            logger.info("Media file stored to: " + savedFilePathOrId)
-            if (Config.mediaStore.isValidSound(fileToStore)) {
-              soundsBuffer += savedFilePathOrId
-            } else if (Config.mediaStore.isValidVideo(fileToStore)) {
-              videosBuffer += savedFilePathOrId
-            } else {
-              imagesBuffer += savedFilePathOrId
-            }
-            associatedMediaBuffer += filename
+      // save() checks to see if the media has already been stored
+      val savedTo = Config.mediaStore.save(fr.uuid, fr.attribution.dataResourceUid, fileToStore, media)
+      savedTo match {
+        case Some((savedFilename, savedFilePathOrId)) => {
+          if (Config.mediaStore.isValidSound(fileToStore)) {
+            soundsBuffer += savedFilePathOrId
+          } else if (Config.mediaStore.isValidVideo(fileToStore)) {
+            videosBuffer += savedFilePathOrId
+          } else {
+            imagesBuffer += savedFilePathOrId
           }
-          case None => logger.warn("Unable to save file: " + fileToStore)
+          associatedMediaBuffer += savedFilename
         }
+        case None => logger.warn("Unable to save file: " + fileToStore)
       }
 
       //add the references

--- a/src/test/scala/au/org/ala/biocache/load/MapDataLoaderTest.scala
+++ b/src/test/scala/au/org/ala/biocache/load/MapDataLoaderTest.scala
@@ -27,9 +27,37 @@ class MapDataLoaderTest extends ConfigFunSuite {
     val jmap = new util.HashMap[String,String]()
     map.foreach{case(k,v)=> jmap.put(k,v)}
     loader.load("drnq",List(jmap),List("occurrenceId"))
-    println(Config.persistenceManager.get("drnq|myid","occ"))
+    //println(Config.persistenceManager.get("drnq|myid","occ"))
     val rights= Config.persistenceManager.get("drnq|myid","occ","rights")
     expectResult(Some("CC")){rights}
     expectResult(Some("Red Kangaroo")){Config.persistenceManager.get("drnq|myid","occ","vernacularName")}
   }
+
+  test("map load empty values"){
+    val loader = new MapDataLoader
+    val map = Map("occurrenceId"->"myid2","scientificName"->"Macropus rufus","eventDate"->"","imageLicence"->"CC", "commonName"->"Red Kangaroo")
+    val jmap = new util.HashMap[String,String]()
+    map.foreach{case(k,v)=> jmap.put(k,v)}
+    loader.load("drnq",List(jmap),List("occurrenceId"))
+    //println(Config.persistenceManager.get("drnq|myid2","occ"))
+    expectResult(None){Config.persistenceManager.get("drnq|myid2","occ","eventDate")}
+  }
+
+  test("map update empty values"){
+    val loader = new MapDataLoader
+    val map = Map("occurrenceId"->"myid3","scientificName"->"Macropus rufus","eventDate"->"2016-02-03","imageLicence"->"CC", "commonName"->"")
+    val jmap = new util.HashMap[String,String]()
+    map.foreach{case(k,v)=> jmap.put(k,v)}
+    loader.load("drnq",List(jmap),List("occurrenceId"))
+    //println(Config.persistenceManager.get("drnq|myid2","occ"))
+    expectResult(Some("2016-02-03")){Config.persistenceManager.get("drnq|myid3","occ","eventDate")}
+    expectResult(None){Config.persistenceManager.get("drnq|myid3","occ","vernacularName")}
+    val map2 = Map("occurrenceId"->"myid3", "eventDate"->"", "commonName"->"Red Kangaroo")
+    val jmap2 = new util.HashMap[String,String]()
+    map2.foreach{case(k,v)=> jmap2.put(k,v)}
+    loader.load("drnq",List(jmap2),List("occurrenceId"))
+    expectResult(Some("2016-02-03")){Config.persistenceManager.get("drnq|myid3","occ","eventDate")}
+    expectResult(Some("Red Kangaroo")){Config.persistenceManager.get("drnq|myid3","occ","vernacularName")}
+  }
+
 }


### PR DESCRIPTION
Fix for #113
Reloads of datasets with images that are already loaded end up with no linked images in the occurrence record.