### PR TITLE
fix for AtlasOfLivingAustralia/data-management#221

### DIFF
--- a/src/main/scala/au/org/ala/biocache/load/DwcCSVLoader.scala
+++ b/src/main/scala/au/org/ala/biocache/load/DwcCSVLoader.scala
@@ -219,7 +219,7 @@ class DwcCSVLoader extends DataLoader {
           case (key,value) => {
             if(value != null){
               val upperCased = value.trim.toUpperCase
-              upperCased != "NULL" && upperCased != "N/A" && upperCased != "\\N" && upperCased != ""
+              upperCased != "NULL" && upperCased != "N/A" && upperCased != "\\N" && upperCased != "" && upperCased != "-"
             } else {
               false
             }


### PR DESCRIPTION
dash '-' values are ignored when loading from csv