### PR TITLE
Fix #167 Add DwCALoader to CMD2 as load-dwca

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,13 +226,18 @@
         <dependency>
             <groupId>org.gbif</groupId>
             <artifactId>dwca-io</artifactId>
-            <version>1.27</version>
+            <version>1.28</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.gbif</groupId>
+            <artifactId>gbif-common</artifactId>
+            <version>0.29</version>
         </dependency>
         <!-- Google Commons -->
         <dependency>
@@ -571,7 +576,7 @@
         <dependency>
             <groupId>org.gbif.crawler</groupId>
             <artifactId>crawler</artifactId>
-            <version>0.20</version>
+            <version>0.27</version>
         </dependency>
     </dependencies>
     <organization>

--- a/src/main/scala/au/org/ala/biocache/cmd/CMD2.scala
+++ b/src/main/scala/au/org/ala/biocache/cmd/CMD2.scala
@@ -208,6 +208,7 @@ object CMD2 {
     DownloadMedia,
     DuplicationDetection,
     DwCACreator,
+    DwCALoader,
     DwcCSVLoader,
     DebugRecord,
     ExpertDistributionOutlierTool,

--- a/src/main/scala/au/org/ala/biocache/load/DwCALoader.scala
+++ b/src/main/scala/au/org/ala/biocache/load/DwCALoader.scala
@@ -4,6 +4,7 @@ import java.io._
 import java.net.URL
 
 import au.org.ala.biocache._
+import au.org.ala.biocache.cmd.{CMD2, NoArgsTool, Tool}
 import au.org.ala.biocache.model.{FullRecord, Multimedia, Raw}
 import au.org.ala.biocache.util.OptionParser
 import au.org.ala.biocache.vocab.DwC
@@ -36,11 +37,14 @@ import scala.collection.{JavaConversions, mutable}
  *
  * @author Dave Martin
  */
-object DwCALoader {
+object DwCALoader extends Tool {
 
   val IMAGE_TYPE = GbifTerm.Image
   val MULTIMEDIA_TYPE = GbifTerm.Multimedia
 //  val IDENTIFICATION_TYPE = GbifTerm.
+
+  def cmd = "load-dwca"
+  def desc = "Load a Darwin Core Archive"
 
   def main(args: Array[String]): Unit = {
 


### PR DESCRIPTION
Need to directly access DwCALoader to load from a local file, as this possibility is not exposed through Loader/CMD2 so far. This pull request adds a direct link from CMD2 to DwCALoader to support this.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>