### PR TITLE
Add RecordWriter.finalised to track state after finalised is called

### DIFF
--- a/src/main/scala/au/org/ala/biocache/Store.scala
+++ b/src/main/scala/au/org/ala/biocache/Store.scala
@@ -774,5 +774,7 @@ trait RecordWriter {
   def write(record:Array[String])
   /** Performs all the finishing tasks in writing the download file. */
   def finalise
+  /** Returns true if this record writer has been finalised */
+  def finalised(): Boolean
 }
 


### PR DESCRIPTION
This is required to be able to monitor if RecordWriter's are finalised for https://github.com/AtlasOfLivingAustralia/biocache-service/pull/125

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>