### PR TITLE
Fix #192 : SDS records with no coordinates do not have processed values stored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ branches:
   - master
   - cassandra3
 before_install:
-- mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings.xml
-script: mvn clean install deploy -DskipTests=true
+  - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings.xml
+script:
+  - "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && mvn -X clean install deploy -DskipTests || mvn -X clean install -DskipTests
 env:
   global:
   - secure: ESKmT8MqCMhcmqlBdnhwv/EJOSuUYSAeTDdA/oXBC9g61k6KrxWZorqylh02LOqamg2r1tUn5i+H+L6vT0tEezdyO1+raFE7gMasbDmlPl/tqAKrwsU0x9YpeqFa2N48xlQlGVw4PfavBoeJ5WCwUovakhvmYauAEhc92rIXr7U=

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 before_install:
   - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings.xml
 script:
-  - "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && mvn -X clean install deploy -DskipTests || mvn -X clean install -DskipTests
+  - "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && mvn -X clean install deploy -DskipTests || mvn -X clean install -DskipTests"
 env:
   global:
   - secure: ESKmT8MqCMhcmqlBdnhwv/EJOSuUYSAeTDdA/oXBC9g61k6KrxWZorqylh02LOqamg2r1tUn5i+H+L6vT0tEezdyO1+raFE7gMasbDmlPl/tqAKrwsU0x9YpeqFa2N48xlQlGVw4PfavBoeJ5WCwUovakhvmYauAEhc92rIXr7U=

--- a/src/main/scala/au/org/ala/biocache/processor/SensitivityProcessor.scala
+++ b/src/main/scala/au/org/ala/biocache/processor/SensitivityProcessor.scala
@@ -208,7 +208,16 @@ class SensitivityProcessor extends Processor {
         //update the raw record with whatever is left in the stringMap - change to use DAO method...
         if(StringUtils.isNotBlank(raw.rowKey)){
           Config.persistenceManager.put(raw.rowKey, "occ", stringMap.toMap, false)
-          LocationDAO.storePointForSampling(processed.location.decimalLatitude, processed.location.decimalLongitude)
+          try {
+            if(StringUtils.isNotBlank(processed.location.decimalLatitude) && 
+               StringUtils.isNotBlank(processed.location.decimalLongitude)) {
+              LocationDAO.storePointForSampling(processed.location.decimalLatitude, processed.location.decimalLongitude)
+            }
+          } catch {
+            case e: Exception => {
+              logger.error("Error storing point for sampling for SDS record: " + raw.rowKey + " " + processed.uuid, e)
+            }
+          }
         }
 
       } else if (!outcome.isLoadable() && Config.obeySDSIsLoadable){


### PR DESCRIPTION
Adds exception handling along with a check to avoid the cause of issue #192 and allow the results of other processors to be used to update the relevant records. Also specifically isolates failures in the location sampling store process from preventing the rest of the SensitivityProcessor from successfully completing.