### PR TITLE
Issue #198 : Support alternative URL returned by images API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ target
 .project
 .classpath
 *-distribution.zip
+.cache-main
+.cache-tests
+.tmpBin/
+

--- a/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
+++ b/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
@@ -262,7 +262,12 @@ object RemoteMediaStore extends MediaStore {
         val params:java.util.List[NameValuePair] = URLEncodedUtils.parse(uri, "UTF-8")
         for(param <- params) {
           if(param.getName.toLowerCase == "imageid"){
-            imageId = Some(param.getValue())
+            val originalUUID = param.getValue().toLowerCase
+            val testUUID = UUID.fromString(originalUUID)
+            val reformedString = testUUID.toString.toLowerCase
+            if (originalUUID == reformedString) {
+              imageId = Some(originalUUID)
+            }
           }
         }
       }
@@ -273,10 +278,11 @@ object RemoteMediaStore extends MediaStore {
           // Do not attempt parsing short segments
           if(pathSegment.length() > 10) {
             try {
-              val testUUID = UUID.fromString(pathSegment)
+              val originalUUID = pathSegment.toLowerCase
+              val testUUID = UUID.fromString(originalUUID)
               val reformedString = testUUID.toString.toLowerCase
-              if (pathSegment == reformedString) {
-                imageId = Some(pathSegment)
+              if (originalUUID == reformedString) {
+                imageId = Some(originalUUID)
               }
             } catch {
               case e:Exception => {

--- a/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
+++ b/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
@@ -255,14 +255,17 @@ object RemoteMediaStore extends MediaStore {
       //  http://images.ala.org.au/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf
       val uri = new URI(urlToMedia)
       val params:java.util.List[NameValuePair] = URLEncodedUtils.parse(uri, "UTF-8")
-      val param = params.get(0)
-      if(param.getName.toLowerCase == "imageid"){
-        val imageId = param.getValue()
-        val imageMetadataUrl = new URL(Config.remoteMediaStoreUrl + "/ws/getImageInfo?id=" + imageId)
-        val response = Source.fromURL(imageMetadataUrl).getLines().mkString
-        val metadata = Json.toMap(response)
-        return Some(metadata.getOrElse("originalFileName", "").toString, param.getValue())
+      for(param <- params) {
+        if(param.getName.toLowerCase == "imageid"){
+          val imageId = param.getValue()
+          val imageMetadataUrl = new URL(Config.remoteMediaStoreUrl + "/ws/getImageInfo?id=" + imageId)
+          val response = Source.fromURL(imageMetadataUrl).getLines().mkString
+          val metadata = Json.toMap(response)
+          return Some(metadata.getOrElse("originalFileName", "").toString, param.getValue())
+        }
       }
+      
+      return None
     }
 
     //already stored?

--- a/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
+++ b/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
@@ -252,18 +252,19 @@ object RemoteMediaStore extends MediaStore {
 
     //is the supplied URL an image service URL ?? If so extract imageID and return.....
     if(urlToMedia.startsWith(Config.remoteMediaStoreUrl)){
-      logger.info("Remote media store URL recognised: " + urlToMedia)
+      logger.info("Remote media store host recognised: " + urlToMedia)
       val uri = new URI(urlToMedia)
-      val imageId = if(urlToMedia.contains("/image/proxy")) {
+      var imageId = Some("")
+      
+      if(urlToMedia.contains("/image/proxy")) {
       // Case 1:
       //   http://images.ala.org.au/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf
         val params:java.util.List[NameValuePair] = URLEncodedUtils.parse(uri, "UTF-8")
         for(param <- params) {
           if(param.getName.toLowerCase == "imageid"){
-            Some(param.getValue())
+            imageId = Some(param.getValue())
           }
         }
-        None
       }
       // Case 2:
       //   http://images.ala.org.au/store/e/7/f/3/eb024033-4da4-4124-83f7-317365783f7e/original
@@ -272,8 +273,11 @@ object RemoteMediaStore extends MediaStore {
           // Do not attempt parsing short segments
           if(pathSegment.length() > 10) {
             try {
-              UUID.fromString(pathSegment)
-              Some(pathSegment)
+              val testUUID = UUID.fromString(pathSegment)
+              val reformedString = testUUID.toString.toLowerCase
+              if (pathSegment == reformedString) {
+                imageId = Some(pathSegment)
+              }
             } catch {
               case e:Exception => {
                 // Ignore, as path segment may not have been the UUID
@@ -281,20 +285,16 @@ object RemoteMediaStore extends MediaStore {
             }
           }
         }
-        None
-      }
-      else {
-        None
       }
       
-      if(imageId.isEmpty) {
+      if(imageId.isEmpty || imageId.get.isEmpty) {
         logger.info("Did not recognise URL pattern for remote media store: {}", urlToMedia)
-        None
+        return None
       } else {
         val imageMetadataUrl = new URL(Config.remoteMediaStoreUrl + "/ws/getImageInfo?id=" + imageId.get)
         val response = Source.fromURL(imageMetadataUrl).getLines().mkString
         val metadata = Json.toMap(response)
-        Some((metadata.getOrElse("originalFileName", "").toString, imageId.get))
+        return Some((metadata.getOrElse("originalFileName", "").toString, imageId.get))
       }
     }
 

--- a/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
+++ b/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
@@ -182,8 +182,12 @@ class MediaStoreTest extends ConfigFunSuite {
     val tests = List(
       ("test valid image/proxyImage", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf",true),
       ("test invalid image/proxyImage, no imageId",Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?id=119d85b5-76cb-4d1d-af30-e141706be8bf", false),
+      ("test invalid image/proxyImage, bad UUID",Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-1d-af30-e141706be8bf", false),
+      ("test valid image/proxyImage uppercase", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119D85B5-76CB-4D1D-AF30-E141706BE8BF",true),
       ("test valid store" ,Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-4124-83f7-317365783f7e/original", true),
-      ("test invalid store, bad UUID",Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-414-83f7-317365783f7e/original", false)
+      ("test valid store uppercase" ,Config.remoteMediaStoreUrl + "/store/e/7/f/3/EB024033-4DA4-4124-83F7-317365783F7E/original", true),
+      ("test invalid store, bad UUID",Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-414-83f7-317365783f7e/original", false),
+      ("test invalid store, no UUID",Config.remoteMediaStoreUrl + "/store/e/7/f/3/31736578/original", false)
     )
 
     tests.foreach { it =>

--- a/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
+++ b/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
@@ -177,4 +177,24 @@ class MediaStoreTest extends ConfigFunSuite {
     expectResult("raw"){ store.extractFileName("http://localhost/nowhere/nothing1/")}
   }
 
+  test("save media store url id detection") {
+
+    val tests = List(
+      ("test valid image/proxyImage", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf",true),
+      ("test invalid image/proxyImage, no imageId",Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?id=119d85b5-76cb-4d1d-af30-e141706be8bf", false),
+      ("test valid store" ,Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-4124-83f7-317365783f7e/original", true),
+      ("test invalid store, bad UUID",Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-414-83f7-317365783f7e/original", false)
+    )
+
+    tests.foreach { it =>
+      logger.info(it._1)
+      expectResult(it._3) {
+        Config.mediaStore.save("", "", it._2, None) match {
+          case Some((filename, filepath)) => true
+          case None => false
+        }
+      }
+    }
+  }
+  
 }


### PR DESCRIPTION
The images API returns various URL forms containing its internal UUID identifier. This pull request attempts to support another of the variations, those containing "/store/" and the UUID in the path, rather than as a query parameter as was supported in the previous version.

This fixes #198