### PR TITLE
issue #210 : Allow overriding of escape and quote characters

### DIFF
--- a/src/main/scala/au/org/ala/biocache/index/BulkProcessor.scala
+++ b/src/main/scala/au/org/ala/biocache/index/BulkProcessor.scala
@@ -60,6 +60,8 @@ object BulkProcessor extends Tool with Counter with RangeCalculator {
     var deleteSources = false
     var includeRowkey = true
     var charSeparator = '\t'
+    var charQuote = '"'
+    var charEscape = '\\'
     var cassandraFilterFile = ""
 
     val parser = new OptionParser(help) {
@@ -115,8 +117,14 @@ object BulkProcessor extends Tool with Counter with RangeCalculator {
       opt("erk", "exclude-rowkey", "Exclude rowkey from export.", {
         includeRowkey = false
       })
-      opt("sep", "char=separator", "Character separator for CSV exports. Defaults to tab.", {
+      opt("sep", "char=separator", "Character separator for TSV exports. Defaults to tab.", {
         v: String => charSeparator = v.trim().charAt(0)
+      })
+      opt("quo", "quoteChar", "Character quote for TSV exports. Defaults to \".", {
+        v: String => charQuote = v.trim().charAt(0)
+      })
+      opt("esc", "escapeChar", "Character escape for TSV exports. Defaults to \\.", {
+        v: String => charEscape = v.trim().charAt(0)
       })
       opt("sm", "skipMerge", "Force merge of segments. Default is " + forceMerge + ". For index only.", { forceMerge = false })
       intOpt("ms", "max segments", "Max merge segments. Default " + mergeSegments + ". For index only.", {
@@ -213,7 +221,7 @@ object BulkProcessor extends Tool with Counter with RangeCalculator {
                 if (columns.isEmpty) {
                   new ColumnReporterRunner(this, counter, startKey, endKey)
                 } else {
-                  new ColumnExporter(this, counter, startKey, endKey, columns.get.toList, includeRowkey, charSeparator)
+                  new ColumnExporter(this, counter, startKey, endKey, columns.get.toList, includeRowkey, charSeparator, charQuote, charEscape)
                 }
               } else {
                 new Thread()

--- a/src/main/scala/au/org/ala/biocache/index/IndexRecordMultiThreaded.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexRecordMultiThreaded.scala
@@ -140,14 +140,14 @@ trait RangeCalculator {
  * @param endKey
  * @param columns
  */
-class ColumnExporter(centralCounter: Counter, threadId: Int, startKey: String, endKey: String, columns: List[String], includeRowkey:Boolean, separator:Char = '\t') extends Runnable {
+class ColumnExporter(centralCounter: Counter, threadId: Int, startKey: String, endKey: String, columns: List[String], includeRowkey:Boolean, separator:Char = '\t', quoteChar:Char = '"', escapeChar:Char = '\\') extends Runnable {
 
   val logger = LoggerFactory.getLogger("ColumnExporter")
 
   def run {
 
     val outWriter = new FileWriter(new File( Config.tmpWorkDir + "/fullexport" + threadId + ".txt"))
-    val writer = new CSVWriter(outWriter, separator, '"', '\\')
+    val writer = new CSVWriter(outWriter, separator, quoteChar, escapeChar)
     if (includeRowkey) writer.writeNext(Array("rowKey") ++ columns.toArray[String])
     else writer.writeNext(columns.toArray[String])
     val start = System.currentTimeMillis


### PR DESCRIPTION
Need to be able to specify escape and quote characters to switch from the TSV default to a CSV exporter

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>