### PR TITLE
Fix #218 : Add metadata calls to identify sounds more often

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <org.springframework.version>3.0.6.RELEASE</org.springframework.version>
         <solr.version>4.10.4</solr.version>
         <jts.version>1.13</jts.version>
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.9.0</jackson.version>
         <gt.version>11.1</gt.version>
         <!-- These properties are used by ala-parent-pom to validate our compliance with this JDK API and bytecode -->
         <targetJdk>1.8</targetJdk>

--- a/src/main/scala/au/org/ala/biocache/util/HttpUtil.scala
+++ b/src/main/scala/au/org/ala/biocache/util/HttpUtil.scala
@@ -8,10 +8,16 @@ import scala.io.Source
 import java.io.File
 import org.apache.http.entity.StringEntity
 import org.slf4j.LoggerFactory
+import java.net.URL
 
 object HttpUtil {
 
   val logger = LoggerFactory.getLogger("HttpUtil")
+
+  def get(url: String) : (String) = {
+    val result = Source.fromURL(new URL(url)).mkString
+    result
+  }
 
   def postBody(url:String, contentType:String, stringBody:String ) : (Int, String) = {
     val httpClient = new DefaultHttpClient()

--- a/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
+++ b/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
@@ -68,6 +68,11 @@ class TestMediaStore extends MediaStore {
   }
 
   override def alreadyStored(uuid: String, resourceUID: String, urlToMedia: String): (Boolean, String, String) = (false, "", "")
+
+  override def getMetadata(uuid: String): java.util.Map[String, Object] = {
+    val result = new java.util.HashMap[String, Object]
+    result
+  }
 }
 
 


### PR DESCRIPTION
Adds a call during loading to the media store metadata service, which was already being called, albeit using another API path. This call is designed to more accurately identify sound/video/images. The call should be fixed load on the database, as the sql database has an index on the guid value and should have a constant-time lookup O(1) for each call.

Running this version of biocache store has made the sound panel show up for dr341 records such as those found by:

http://biocache.ala.org.au/occurrences/search?q=data_resource_uid%3Adr341&fq=multimedia%3A%22Image%22&fq=basis_of_record%3A%22MachineObservation%22

I haven't reindexed the records, which may change the results of that query (possibly returning nothing afterwards if the multimedia value changes), however, the load/process/sample sequence has done something to cassandra, which is enabling the sound player to show up. The image viewer is also showing up, so not sure how/what to do about that, but it isn't as vital as having the sound player available.

It checks the media type against the major content type groups, "audio/", "video/" and "image/", before still defaulting to "image" in other cases, with a log warning. All legitimate images should match against "image/" for their content type, so it is unexpected that the log warning will ever show up in normal circumstances.

If this code could be integrated this week it would be great, given the original request to start work on this was made in February.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>