### PR TITLE
Fix #212 : Extract default values from collectory for Darwin Core Archive meta.xml

### DIFF
--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -12,6 +12,7 @@ import au.org.ala.biocache.Config
 import au.org.ala.biocache.util.OptionParser
 import util.matching.Regex
 import au.org.ala.biocache.cmd.Tool
+import java.nio.charset.StandardCharsets
 
 /**
  * Companion object for the DwCACreator class.
@@ -125,7 +126,7 @@ class GBIFOrgDwCACreator {
     try {
       zop.putNextEntry(new ZipEntry("eml.xml"))
       val content = Source.fromURL(Config.registryUrl + "/eml/" + dr).mkString
-      zop.write(content.getBytes)
+      zop.write(content.getBytes(StandardCharsets.UTF_8))
       zop.flush
       zop.closeEntry
       true
@@ -151,9 +152,9 @@ class GBIFOrgDwCACreator {
       </core>
     </archive>
     //add the XML
-    zop.write("""<?xml version="1.0"?>""".getBytes)
-    zop.write("\n".getBytes)
-    zop.write(metaXml.mkString("\n").getBytes)
+    zop.write("""<?xml version="1.0"?>""".getBytes(StandardCharsets.UTF_8))
+    zop.write("\n".getBytes(StandardCharsets.UTF_8))
+    zop.write(metaXml.mkString("\n").getBytes(StandardCharsets.UTF_8))
     zop.flush
     zop.closeEntry
   }
@@ -163,7 +164,7 @@ class GBIFOrgDwCACreator {
     val startUuid = dr + "|"
     val endUuid = startUuid + "~"
     ExportUtil.export(
-      new CSVWriter(new OutputStreamWriter(zop)),
+      new CSVWriter(new OutputStreamWriter(zop, StandardCharsets.UTF_8)),
       "occ",
       defaultFields,
       List("uuid"),

--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -142,12 +142,12 @@ class GBIFOrgDwCACreator {
     val defaultsFromCollectory = json.get("defaultDarwinCoreValues")
     val fieldsString = new StringBuilder()
     fieldsString.append("<archive xmlns=\"http://rs.tdwg.org/dwc/text/\" metadata=\"eml.xml\">\n")
-    fieldsString.append("  <core encoding=\"UTF-8\" linesTerminatedBy=\"\\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.tdwg.org/dwc/terms/Occurrence\">")
-    fieldsString.append("    <files>")
-    fieldsString.append("      <location>occurrence.csv</location>")
-    fieldsString.append("    </files>")
-    fieldsString.append("    <id index=\"0\"/>")
-    fieldsString.append("    <field index=\"0\" term=\"http://rs.tdwg.org/dwc/terms/occurrenceID\"/>")
+    fieldsString.append("  <core encoding=\"UTF-8\" linesTerminatedBy=\"\\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.tdwg.org/dwc/terms/Occurrence\">\n")
+    fieldsString.append("    <files>\n")
+    fieldsString.append("      <location>occurrence.csv</location>\n")
+    fieldsString.append("    </files>\n")
+    fieldsString.append("    <id index=\"0\"/>\n")
+    fieldsString.append("    <field index=\"0\" term=\"http://rs.tdwg.org/dwc/terms/occurrenceID\"/>\n")
     for (nextField <- defaultFields) {
       fieldsString.append("<field index=\"")
       fieldsString.append(defaultFields.indexOf(nextField).toString())
@@ -164,8 +164,8 @@ class GBIFOrgDwCACreator {
       }
       fieldsString.append(" />\n")
     }
-    fieldsString.append("  </core>")
-    fieldsString.append("</archive>")
+    fieldsString.append("  </core>\n")
+    fieldsString.append("</archive>\n")
     //add the XML
     zop.putNextEntry(new ZipEntry("meta.xml"))
     zop.write("""<?xml version="1.0"?>""".getBytes(StandardCharsets.UTF_8))

--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -148,21 +148,27 @@ class GBIFOrgDwCACreator {
     fieldsString.append("    </files>\n")
     fieldsString.append("    <id index=\"0\"/>\n")
     fieldsString.append("    <field index=\"0\" term=\"http://rs.tdwg.org/dwc/terms/occurrenceID\"/>\n")
+    var skippedFirst = false
     for (nextField <- defaultFields) {
-      fieldsString.append("<field index=\"")
-      fieldsString.append(defaultFields.indexOf(nextField).toString())
-      fieldsString.append("\" term=\"http://rs.tdwg.org/dwc/terms/")
-      fieldsString.append(nextField)
-      fieldsString.append("\" ")
-      if(defaultsFromCollectory.isDefined) {
-        val defaultsMap = defaultsFromCollectory.get.asInstanceOf[Map[String, Any]]
-        if(defaultsMap.contains(nextField)) {
-          fieldsString.append(" default=\"")
-          fieldsString.append(defaultsMap.get(nextField).get.toString())
-          fieldsString.append("\" ")
+      if(!skippedFirst) {
+        // First item hardcoded as occurrenceID, we must skip whatever is first on the list, should be uuid that isn't in Darwin Core Terms
+        skippedFirst = true
+      } else {
+        fieldsString.append("<field index=\"")
+        fieldsString.append(defaultFields.indexOf(nextField).toString())
+        fieldsString.append("\" term=\"http://rs.tdwg.org/dwc/terms/")
+        fieldsString.append(nextField)
+        fieldsString.append("\" ")
+        if(defaultsFromCollectory.isDefined) {
+          val defaultsMap = defaultsFromCollectory.get.asInstanceOf[Map[String, Any]]
+          if(defaultsMap.contains(nextField)) {
+            fieldsString.append(" default=\"")
+            fieldsString.append(defaultsMap.get(nextField).get.toString())
+            fieldsString.append("\" ")
+          }
         }
+        fieldsString.append(" />\n")
       }
-      fieldsString.append(" />\n")
     }
     fieldsString.append("  </core>\n")
     fieldsString.append("</archive>\n")

--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -110,7 +110,7 @@ class GBIFOrgDwCACreator {
     FileUtils.forceMkdir(zipFile.getParentFile)
     val zop = new ZipOutputStream(new FileOutputStream(zipFile))
     if(addEML(zop, dataResource)){
-      addMeta(zop)
+      addMeta(zop, dataResource)
       addCSV(zop, dataResource)
       zop.close
     } else {
@@ -134,7 +134,11 @@ class GBIFOrgDwCACreator {
     }
   }
 
-  def addMeta(zop:ZipOutputStream) ={
+  def addMeta(zop:ZipOutputStream, dr:String) ={
+    val url = Config.registryUrl + "/dataResource/" + dr
+    val jsonString = Source.fromURL(url).getLines.mkString
+    val json = JSON.parseFull(jsonString).get.asInstanceOf[Map[String, String]]
+    val defaultsFromCollectory = json.get("defaultDarwinCoreValues")
     zop.putNextEntry(new ZipEntry("meta.xml"))
     val metaXml = <archive xmlns="http://rs.tdwg.org/dwc/text/" metadata="eml.xml">
       <core encoding="UTF-8" linesTerminatedBy="\r\n" fieldsTerminatedBy="," fieldsEnclosedBy="&quot;" ignoreHeaderLines="0" rowType="http://rs.tdwg.org/dwc/terms/Occurrence">

--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -148,10 +148,10 @@ class GBIFOrgDwCACreator {
       fieldsString.append(nextField)
       fieldsString.append("\" ")
       if(defaultsFromCollectory.isDefined) {
-        val defaultsMap = defaultsFromCollectory.asInstanceOf[Map[String, Any]]
+        val defaultsMap = defaultsFromCollectory.get.asInstanceOf[Map[String, Any]]
         if(defaultsMap.contains(nextField)) {
           fieldsString.append(" default=\"")
-          fieldsString.append(defaultsMap.get(nextField).toString())
+          fieldsString.append(defaultsMap.get(nextField).get.toString())
           fieldsString.append("\" ")
         }
       }

--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -141,6 +141,13 @@ class GBIFOrgDwCACreator {
     val json = JSON.parseFull(jsonString).get.asInstanceOf[Map[String, Any]]
     val defaultsFromCollectory = json.get("defaultDarwinCoreValues")
     val fieldsString = new StringBuilder()
+    fieldsString.append("<archive xmlns=\"http://rs.tdwg.org/dwc/text/\" metadata=\"eml.xml\">\n")
+    fieldsString.append("  <core encoding=\"UTF-8\" linesTerminatedBy=\"\r\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.tdwg.org/dwc/terms/Occurrence\">")
+    fieldsString.append("    <files>")
+    fieldsString.append("      <location>occurrence.csv</location>")
+    fieldsString.append("    </files>")
+    fieldsString.append("    <id index=\"0\"/>")
+    fieldsString.append("    <field index=\"0\" term=\"http://rs.tdwg.org/dwc/terms/occurrenceID\"/>")
     for (nextField <- defaultFields) {
       fieldsString.append("<field index=\"")
       fieldsString.append(defaultFields.indexOf(nextField).toString())
@@ -157,22 +164,13 @@ class GBIFOrgDwCACreator {
       }
       fieldsString.append(" />\n")
     }
-    //{defaultFields.tail.map(f =>  <field index={defaultFields.indexOf(f).toString} term={"http://rs.tdwg.org/dwc/terms/"+f} {if (defaultsFromCollectory.contains(f)) {default={defaultsFromCollectory.get(f)} }/>)}
-    zop.putNextEntry(new ZipEntry("meta.xml"))
-    val metaXml = <archive xmlns="http://rs.tdwg.org/dwc/text/" metadata="eml.xml">
-      <core encoding="UTF-8" linesTerminatedBy="\r\n" fieldsTerminatedBy="," fieldsEnclosedBy="&quot;" ignoreHeaderLines="0" rowType="http://rs.tdwg.org/dwc/terms/Occurrence">
-      <files>
-            <location>occurrence.csv</location>
-      </files>
-            <id index="0"/>
-            <field index="0" term="http://rs.tdwg.org/dwc/terms/occurrenceID"/>
-            { fieldsString.toString() }
-      </core>
-    </archive>
+    fieldsString.append("  </core>")
+    fieldsString.append("</archive>")
     //add the XML
+    zop.putNextEntry(new ZipEntry("meta.xml"))
     zop.write("""<?xml version="1.0"?>""".getBytes(StandardCharsets.UTF_8))
     zop.write("\n".getBytes(StandardCharsets.UTF_8))
-    zop.write(metaXml.mkString("\n").getBytes(StandardCharsets.UTF_8))
+    zop.write(fieldsString.toString().getBytes(StandardCharsets.UTF_8))
     zop.flush
     zop.closeEntry
   }

--- a/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
+++ b/src/main/scala/au/org/ala/biocache/export/GBIFOrgDwCACreator.scala
@@ -142,7 +142,7 @@ class GBIFOrgDwCACreator {
     val defaultsFromCollectory = json.get("defaultDarwinCoreValues")
     val fieldsString = new StringBuilder()
     fieldsString.append("<archive xmlns=\"http://rs.tdwg.org/dwc/text/\" metadata=\"eml.xml\">\n")
-    fieldsString.append("  <core encoding=\"UTF-8\" linesTerminatedBy=\"\r\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.tdwg.org/dwc/terms/Occurrence\">")
+    fieldsString.append("  <core encoding=\"UTF-8\" linesTerminatedBy=\"\\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.tdwg.org/dwc/terms/Occurrence\">")
     fieldsString.append("    <files>")
     fieldsString.append("      <location>occurrence.csv</location>")
     fieldsString.append("    </files>")


### PR DESCRIPTION
The GBIF export does not contain default values, as it does not include processed values.

This has led to a large majority of the ALA datasets that rely on defaults for the basisOfRecord field from the collectory being labelled as invalid.

These changes attempt to retrieve the default values from the collectory and use them in the meta.xml file, where a Darwin Core Archive reader implementation could be expected to find them and patch them into records as necessary.