### PR TITLE
Duplicate double quotes in the field names

### DIFF
--- a/src/main/scala/au/org/ala/biocache/persistence/Cassandra3PersistenceManager.scala
+++ b/src/main/scala/au/org/ala/biocache/persistence/Cassandra3PersistenceManager.scala
@@ -517,7 +517,7 @@ class Cassandra3PersistenceManager @Inject()(
   def addFieldToEntity(entityName: String, fieldName: String): Unit = {
     val resultset =
       if (Config.caseSensitiveCassandra) {
-        session.execute("ALTER TABLE " + entityName + " ADD \"" + fieldName + "\" varchar")
+        session.execute("ALTER TABLE " + entityName + " ADD " + fieldName + " varchar")
       } else {
         session.execute(s"ALTER TABLE $entityName ADD $fieldName varchar")
       }


### PR DESCRIPTION
Exception occurred while adding  "dcterms:accessRights", which already has double quotes. 