### PR TITLE
issue #232 : Add support for alternate http/https mediastore

### DIFF
--- a/src/main/scala/au/org/ala/biocache/Config.scala
+++ b/src/main/scala/au/org/ala/biocache/Config.scala
@@ -1,6 +1,7 @@
 package au.org.ala.biocache
 
 import java.io.{File, FileInputStream}
+import java.net.{URI, URL}
 import java.util.Properties
 import java.util.jar.Attributes
 
@@ -54,6 +55,25 @@ object Config {
     } else {
       logger.debug("Using remote media store")
       RemoteMediaStore
+    }
+  }
+
+  val remoteMediaStoreUrlAlternate = {
+    if(StringUtils.isBlank(remoteMediaStoreUrl)){
+      logger.debug("Using local media store")
+      ""
+    } else {
+      logger.debug("Using remote media store")
+      val parsedUrl = new URL(remoteMediaStoreUrl)
+      val protocol = parsedUrl.getProtocol()
+      val result = remoteMediaStoreUrl.replaceFirst(protocol + ":", "")
+      // Switch protocols so we are not biased against one or the other for matching purposes
+      // Still use the configured remoteMediaStoreUrl when constructing URLs to resolve
+      if (protocol.equalsIgnoreCase("https")) {
+        "http:" + result
+      } else {
+        "https:" + result
+      }
     }
   }
 

--- a/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
+++ b/src/main/scala/au/org/ala/biocache/load/MediaStore.scala
@@ -253,7 +253,7 @@ object RemoteMediaStore extends MediaStore {
   def save(uuid: String, resourceUID: String, urlToMedia: String, media: Option[Multimedia]): Option[(String, String)] = {
 
     //is the supplied URL an image service URL ?? If so extract imageID and return.....
-    if(urlToMedia.startsWith(Config.remoteMediaStoreUrl)){
+    if(urlToMedia.startsWith(Config.remoteMediaStoreUrl) || urlToMedia.startsWith(Config.remoteMediaStoreUrlAlternate)){
       logger.info("Remote media store host recognised: " + urlToMedia)
       val uri = new URI(urlToMedia)
       var imageId = Some("")

--- a/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
+++ b/src/test/scala/au/org/ala/biocache/load/MediaStoreTest.scala
@@ -186,13 +186,19 @@ class MediaStoreTest extends ConfigFunSuite {
 
     val tests = List(
       ("test valid image/proxyImage", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf",true),
-      ("test invalid image/proxyImage, no imageId",Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?id=119d85b5-76cb-4d1d-af30-e141706be8bf", false),
-      ("test invalid image/proxyImage, bad UUID",Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-1d-af30-e141706be8bf", false),
+      ("test invalid image/proxyImage, no imageId", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?id=119d85b5-76cb-4d1d-af30-e141706be8bf", false),
+      ("test invalid image/proxyImage, bad UUID", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-1d-af30-e141706be8bf", false),
       ("test valid image/proxyImage uppercase", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119D85B5-76CB-4D1D-AF30-E141706BE8BF",true),
-      ("test valid store" ,Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-4124-83f7-317365783f7e/original", true),
-      ("test valid store uppercase" ,Config.remoteMediaStoreUrl + "/store/e/7/f/3/EB024033-4DA4-4124-83F7-317365783F7E/original", true),
-      ("test invalid store, bad UUID",Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-414-83f7-317365783f7e/original", false),
-      ("test invalid store, no UUID",Config.remoteMediaStoreUrl + "/store/e/7/f/3/31736578/original", false)
+      ("test valid image/proxyImage alternate protocol", Config.remoteMediaStoreUrlAlternate + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf",true),
+      ("test valid image/proxyImage default protocol", Config.remoteMediaStoreUrl + "/image/proxyImageThumbnailLarge?imageId=119d85b5-76cb-4d1d-af30-e141706be8bf",true),
+
+      ("test valid store" , Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-4124-83f7-317365783f7e/original", true),
+      ("test valid store uppercase" , Config.remoteMediaStoreUrl + "/store/e/7/f/3/EB024033-4DA4-4124-83F7-317365783F7E/original", true),
+      ("test invalid store, bad UUID", Config.remoteMediaStoreUrl + "/store/e/7/f/3/eb024033-4da4-414-83f7-317365783f7e/original", false),
+      ("test invalid store, no UUID", Config.remoteMediaStoreUrl + "/store/e/7/f/3/31736578/original", false),
+      ("test valid store uppercase alternate protocol" , Config.remoteMediaStoreUrlAlternate + "/store/e/7/f/3/EB024033-4DA4-4124-83F7-317365783F7E/original", true),
+      ("test valid store uppercase default protocol" , Config.remoteMediaStoreUrl + "/store/e/7/f/3/EB024033-4DA4-4124-83F7-317365783F7E/original", true)
+
     )
 
     tests.foreach { it =>


### PR DESCRIPTION
Media store URL is currently used for exact matching, but during the migration process from http to https, it needs to match both.

This fixes #232 by introducing a new constant for the migration process to simultaneously match http and https. Once the migration is complete, this constant could be removed if necessary.