### PR TITLE
Fix #250 : Add initialise method to RecordWriter

### DIFF
--- a/src/main/scala/au/org/ala/biocache/Store.scala
+++ b/src/main/scala/au/org/ala/biocache/Store.scala
@@ -790,6 +790,11 @@ trait OccurrenceVersionConsumer {
   * A trait to be implemented by java classes to write records.
   */
 trait RecordWriter {
+  /** Any resource allocation operations that are cleaned up in the 
+   *  finalise method must be performed during this initialise method. 
+   */
+  def initialise
+
   /** Writes the supplied record. */
   def write(record: Array[String])
 


### PR DESCRIPTION
Need an explicit initialise method to ensure resources expected to be closed in finalise are not created in a constructor where they may be left stranded if construction fails.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>