### PR TITLE
Fix #255 : Add configurable Solr timeouts

### DIFF
--- a/src/main/scala/au/org/ala/biocache/Config.scala
+++ b/src/main/scala/au/org/ala/biocache/Config.scala
@@ -70,6 +70,12 @@ object Config {
   // Configure this and the connection pool size as required to fit a Solr cluster setup if one is in use
   val solrConnectionMaxPerRoute = configModule.properties.getProperty("solr.connection.pool.maxperroute", "50").toInt
 
+  val solrConnectionConnectTimeout = configModule.properties.getProperty("solr.connection.connecttimeout", "30000").toInt
+
+  val solrConnectionRequestTimeout = configModule.properties.getProperty("solr.connection.requesttimeout", "30000").toInt
+
+  val solrConnectionSocketTimeout = configModule.properties.getProperty("solr.connection.sockettimeout", "30000").toInt
+
   val solrConnectionCacheEntries = configModule.properties.getProperty("solr.connection.cache.entries", "500").toInt
 
   // 1024 * 256 = 262144 bytes

--- a/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
@@ -17,6 +17,7 @@ import com.google.inject.Inject
 import com.google.inject.name.Named
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang3.StringEscapeUtils
+import org.apache.http.client.config.RequestConfig
 import org.apache.http.conn.HttpClientConnectionManager
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.impl.client.cache.CacheConfig
@@ -108,6 +109,10 @@ class SolrIndexDAO @Inject()(@Named("solr.home") solrHome: String,
                                      .setMaxCacheEntries(Config.solrConnectionCacheEntries)
                                      .setMaxObjectSize(Config.solrConnectionCacheObjectSize)
                                      .setSharedCache(false).build()
+        val requestConfig = RequestConfig.custom()
+                                         .setConnectTimeout(Config.solrConnectionConnectTimeout)
+                                         .setConnectionRequestTimeout(Config.solrConnectionRequestTimeout)
+                                         .setSocketTimeout(Config.solrConnectionSocketTimeout).build()
         httpClient = CachingHttpClientBuilder.create()
                                 .setCacheConfig(cacheConfig)
                                 .setConnectionManager(connectionPoolManager)

--- a/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
@@ -115,6 +115,7 @@ class SolrIndexDAO @Inject()(@Named("solr.home") solrHome: String,
                                          .setSocketTimeout(Config.solrConnectionSocketTimeout).build()
         httpClient = CachingHttpClientBuilder.create()
                                 .setCacheConfig(cacheConfig)
+                                .setDefaultRequestConfig(requestConfig)
                                 .setConnectionManager(connectionPoolManager)
                                 .setUserAgent(Config.userAgent)
                                 .useSystemProperties().build()


### PR DESCRIPTION
Adds three configurable timeouts for connections to Solr, one for socket opening, one for opening a connection, and one for getting responses across the connection.

All three timeouts default to 30000ms (30 seconds), but are configurable to suit each individual situation

Without the timeouts set, the requests to Solr would block indefinitely, which causes catastrophic failures when load increases past a maintainable point, even after the load is reduced to maintainable levels.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>