### PR TITLE
Parsing date range end date: leap years

### DIFF
--- a/src/main/scala/au/org/ala/biocache/parser/DateParser.scala
+++ b/src/main/scala/au/org/ala/biocache/parser/DateParser.scala
@@ -486,8 +486,8 @@ object ISODayMonthRange {
       if (parts.length != 2) return None
       val startDateParsed = DateUtils.parseDateStrictly(parts(0),
         Array("yyyy-MM-dd"))
-      val endDateParsed = DateUtils.parseDateStrictly(parts(1),
-        Array("MM-dd"))
+      val endDateParsed = DateUtils.parseDateStrictly(DateFormatUtils.format(startDateParsed, "yyyy") + "-" + parts(1),
+        Array("yyyy-MM-dd")) //end dates of 02-29 must be allowed if leap year: parsing 02-29 without year fails
 
       val startDate = DateFormatUtils.format(startDateParsed, "yyyy-MM-dd")
       val startDay = DateFormatUtils.format(startDateParsed, "dd")


### PR DESCRIPTION
This is just a patch to accommodate a valid range like  2008-01-01/02-29.

Note, as a side-effect, it changes the structure of endDateParsed from MM-dd to yyyy-MM-dd, which means a processed eventdateend is written to Cassandra instead of null. I'm not sure if this should be more generally applied to the other parsers (e.g. ISODayDateRange) to set endDateParsed to a full date, where possible, instead of just the range fragment. It seems reasonable to me, but I don't have sight of the bigger picture necessarily!