### PR TITLE
Additional valid timezone modifiers

### DIFF
--- a/src/main/scala/au/org/ala/biocache/parser/DateParser.scala
+++ b/src/main/scala/au/org/ala/biocache/parser/DateParser.scala
@@ -251,7 +251,7 @@ class SingleDate {
     try {
       //  2001-03-14T00:00:00+11:00
       //bug in commons lang - http://stackoverflow.com/questions/424522/how-can-i-recognize-the-zulu-time-zone-in-java-dateutils-parsedate
-      val strWithoutTime = str.replaceFirst("[+|-][0-2][0-9]:[0-5][0-9]","")
+      var strWithoutTime = str.replaceFirst("[+|-][0-2][0-9]:[0-5][0-9]","")
       if (strWithoutTime == str) {
         //date[+|-]hh or date[+|-]hhmm are also valid time modifiers, but get confused with basic dates like '2008-01-05' or '23-01-2008'
         strWithoutTime = str.replaceFirst("[+][0-2][0-9][0-5][0-9]","") //first get rid of the easy '+' ones

--- a/src/main/scala/au/org/ala/biocache/parser/DateParser.scala
+++ b/src/main/scala/au/org/ala/biocache/parser/DateParser.scala
@@ -252,6 +252,19 @@ class SingleDate {
       //  2001-03-14T00:00:00+11:00
       //bug in commons lang - http://stackoverflow.com/questions/424522/how-can-i-recognize-the-zulu-time-zone-in-java-dateutils-parsedate
       val strWithoutTime = str.replaceFirst("[+|-][0-2][0-9]:[0-5][0-9]","")
+      if (strWithoutTime == str) {
+        //date[+|-]hh or date[+|-]hhmm are also valid time modifiers, but get confused with basic dates like '2008-01-05' or '23-01-2008'
+        strWithoutTime = str.replaceFirst("[+][0-2][0-9][0-5][0-9]","") //first get rid of the easy '+' ones
+        strWithoutTime = str.replaceFirst("[+][0-2][0-9]","")
+        if (strWithoutTime == str) {
+          if (str.split("-").length > 3) {
+            val strRev = str.reverse
+            var strWithoutTimeRev = strRev.replaceFirst("[0-9][0-5][0-9][0-2][-]","") //note pattern reversed
+            strWithoutTimeRev = strRev.replaceFirst("[0-9][0-2][-]","")
+            strWithoutTime = strWithoutTimeRev.reverse
+          }
+        }
+      }
       val eventDateParsed = DateUtils.parseDateStrictly(strWithoutTime,formats)
       val startYear, endYear = DateFormatUtils.format(eventDateParsed, "yyyy")
       val startDate, endDate = DateFormatUtils.format(eventDateParsed, "yyyy-MM-dd")

--- a/src/test/scala/au/org/ala/biocache/DateParserTest.scala
+++ b/src/test/scala/au/org/ala/biocache/DateParserTest.scala
@@ -276,6 +276,61 @@ class DateParserTest extends FunSuite {
     expectResult("14"){result.get.endDay}
     expectResult(true){result.get.singleDate}
   }
+  
+  test("2001-03-14T00:00:00+1100"){
+    val result = DateParser.parseDate("2001-03-14T00:00:00+1100")
+    expectResult(false){result.isEmpty}
+    expectResult("2001"){result.get.startYear}
+    expectResult("03"){result.get.startMonth}
+    expectResult("03"){result.get.endMonth}
+    expectResult("14"){result.get.startDay}
+    expectResult("14"){result.get.endDay}
+    expectResult(true){result.get.singleDate}
+  }
+
+  test("2001-03-14T00:00:00+11"){
+    val result = DateParser.parseDate("2001-03-14T00:00:00+11")
+    expectResult(false){result.isEmpty}
+    expectResult("2001"){result.get.startYear}
+    expectResult("03"){result.get.startMonth}
+    expectResult("03"){result.get.endMonth}
+    expectResult("14"){result.get.startDay}
+    expectResult("14"){result.get.endDay}
+    expectResult(true){result.get.singleDate}
+  }
+
+  test("2001-03-14T00:00:00-11:00"){
+    val result = DateParser.parseDate("2001-03-14T00:00:00-11:00")
+    expectResult(false){result.isEmpty}
+    expectResult("2001"){result.get.startYear}
+    expectResult("03"){result.get.startMonth}
+    expectResult("03"){result.get.endMonth}
+    expectResult("14"){result.get.startDay}
+    expectResult("14"){result.get.endDay}
+    expectResult(true){result.get.singleDate}
+  }
+
+  test("2001-03-14T00:00:00-1130"){
+    val result = DateParser.parseDate("2001-03-14T00:00:00-1130")
+    expectResult(false){result.isEmpty}
+    expectResult("2001"){result.get.startYear}
+    expectResult("03"){result.get.startMonth}
+    expectResult("03"){result.get.endMonth}
+    expectResult("14"){result.get.startDay}
+    expectResult("14"){result.get.endDay}
+    expectResult(true){result.get.singleDate}
+  }
+
+  test("2001-03-14T00:00:00-05"){
+    val result = DateParser.parseDate("2001-03-14T00:00:00-05")
+    expectResult(false){result.isEmpty}
+    expectResult("2001"){result.get.startYear}
+    expectResult("03"){result.get.startMonth}
+    expectResult("03"){result.get.endMonth}
+    expectResult("14"){result.get.startDay}
+    expectResult("14"){result.get.endDay}
+    expectResult(true){result.get.singleDate}
+  }
 
   test("Invalid date ranges"){
     expectResult(None){DateParser.parseDate("2014-02-29")}


### PR DESCRIPTION
For <time>[+|-]hhmm or <time>[+|-]hh

At present, only <time>[+|-]hh:mm is allowed