### PR TITLE
Check for case sensitive lat/longitude field names

### DIFF
--- a/src/main/scala/au/org/ala/biocache/tool/SampleLocalRecords.scala
+++ b/src/main/scala/au/org/ala/biocache/tool/SampleLocalRecords.scala
@@ -185,8 +185,8 @@ class SampleLocalRecords extends Counter {
     var readCount = 0
     var rowkeys = Seq("")
     val queue = new util.HashSet[String]()
-    val dlat = "decimalLatitude" + Config.persistenceManager.fieldDelimiter + "p"
-    val dlon = "decimalLongitude" + Config.persistenceManager.fieldDelimiter + "p"
+    val dlat = (if (Config.caseSensitiveCassandra) "decimalLatitude" else "decimallatitude") + Config.persistenceManager.fieldDelimiter + "p"
+    val dlon = (if (Config.caseSensitiveCassandra) "decimalLongitude" else "decimallongitude") + Config.persistenceManager.fieldDelimiter + "p"
 
     val rowKeyFile : File = if (drs.size == 1) {
       Store.rowKeyFile(drs.iterator.next())


### PR DESCRIPTION
If cassandra is not case sensitive, the field may be "decimallatitude_p" / "decimallongitude_p". In this case, sample-local-node logs each record, but does not process any of them, since it doesn't find the capitalised lat/long field names.