### PR TITLE
Flag an issue verifications for non-case-sensitive databases

### DIFF
--- a/src/main/scala/au/org/ala/biocache/processor/Processors.scala
+++ b/src/main/scala/au/org/ala/biocache/processor/Processors.scala
@@ -37,6 +37,6 @@ object Processors {
     case c if c == UNRECOGNISED_COLLECTIONCODE.code || c == UNRECOGNISED_INSTITUTIONCODE.code => "attr"
     case c if c == INVALID_IMAGE_URL.code => "image"
     case c if c >= temporalBounds._1 && c < temporalBounds._2 => "event"
-    case _ => ""
+    case _ => (if (Config.caseSensitiveCassandra) "" else "default") // the non-case-sensitive cassandra schema does not include the field "_qa"
   }
 }


### PR DESCRIPTION
Possibly the '_qa' field rather needs to be added to the occ.occ schema, though I couldn't get this to work even with that field included.