### PR TITLE
Example case-sensitivity hack

### DIFF
--- a/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAOImpl.scala
+++ b/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAOImpl.scala
@@ -968,7 +968,7 @@ class OccurrenceDAOImpl extends OccurrenceDAO {
         persistenceManager.delete(
           Map(
             "rowkey" -> toBeDeleted.referenceRowKey,
-            "userId" -> toBeDeleted.getUserId,
+            (if (Config.caseSensitiveCassandra) "userId" else "userid") -> toBeDeleted.getUserId,
             "code"   -> toBeDeleted.code.toString
           ),
           qaEntityName


### PR DESCRIPTION
There must be a better way to do this, but here's an example of the sort of code changes I'm making to get this to work with the original case-insensitive cassandra schema. There are quite a few points where this needs to be done, which looks ugly..