### PR TITLE
Handle multiple assertions by single user on single record correctly 

### DIFF
--- a/conf/cassandra3_case_sensitive_schema.txt
+++ b/conf/cassandra3_case_sensitive_schema.txt
@@ -114,7 +114,7 @@ CREATE TABLE occ.qa (
     "userDisplayName" text,
     "userEmail" text,
     uuid text,
-    PRIMARY KEY (rowkey, "userId", code)
+    PRIMARY KEY (rowkey, "userId", code, relatedUuid)
 ) WITH CLUSTERING ORDER BY ("userId" ASC, code ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}

--- a/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAOImpl.scala
+++ b/src/main/scala/au/org/ala/biocache/dao/OccurrenceDAOImpl.scala
@@ -902,7 +902,7 @@ class OccurrenceDAOImpl extends OccurrenceDAO {
     if (!record.isEmpty) {
 
       //preserve the raw record
-      val qaMap = qualityAssertionProperties ++ Map("snapshot" -> Json.toJSON(record.get))
+      val qaMap = qualityAssertionProperties ++ (if (qualityAssertion.relatedUuid == null || qualityAssertion.relatedUuid.isEmpty()) Map("relatedUuid" -> "") else Map()) ++ Map("snapshot" -> Json.toJSON(record.get))
       persistenceManager.put(rowKey, qaEntityName, qaMap, true, false)
       val systemAssertions = getSystemAssertions(rowKey)
       val userAssertions = getUserAssertions(rowKey)
@@ -969,7 +969,8 @@ class OccurrenceDAOImpl extends OccurrenceDAO {
           Map(
             "rowkey" -> toBeDeleted.referenceRowKey,
             "userId" -> toBeDeleted.getUserId,
-            "code"   -> toBeDeleted.code.toString
+            "code"   -> toBeDeleted.code.toString,
+            (if (Config.caseSensitiveCassandra) "relatedUuid" else "relateduuid") -> toBeDeleted.getRelatedUuid 
           ),
           qaEntityName
         )


### PR DESCRIPTION
This may be an edge-case, but the existing primary key setup means that if a user raises more than one issue against a record, then only one verification of these can be saved: the rowkey, userId and code (50005 unconfirmed) would all be the same. Verifying another one of the user's issues against the same record overwrites the first one.

Including the relatedUuid field in the primary key fixes this, BUT it means non-verification qa entries must have an empty string ("") relatedUuid, instead of null, since part of a composite key cannot be null.