### PR TITLE
issue #286 : Threadsafe counts and timing

### DIFF
--- a/src/main/scala/au/org/ala/biocache/export/ExportFromIndexStream.scala
+++ b/src/main/scala/au/org/ala/biocache/export/ExportFromIndexStream.scala
@@ -89,8 +89,8 @@ object ExportFromIndexStream extends Tool with Counter {
     fileWriter.write("\n")
 
     Config.indexDAO.streamIndex(map => {
-      counter += 1
-      if (counter % 1000 == 0) {
+      val lastCounter = counter.incrementAndGet()
+      if (lastCounter % 1000 == 0) {
         logger.info("Exported records: $counter")
         fileWriter.flush
       }

--- a/src/main/scala/au/org/ala/biocache/index/IndexLocalNode.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexLocalNode.scala
@@ -61,7 +61,7 @@ class IndexLocalNode {
                    writerCount: Int,
                    testMap: Boolean,
                    maxRecordsToIndex:Int = -1
-                  ) : Int = {
+                  ) : Long = {
 
     val start = System.currentTimeMillis()
 
@@ -139,7 +139,7 @@ class IndexLocalNode {
     //Move checkpoint file if complete
     new File(checkpointFile).renameTo(new File(checkpointFile + ".complete"))
 
-    counter.counter
+    counter.counter.get()
   }
 
   /**

--- a/src/main/scala/au/org/ala/biocache/index/IndexRunnerMap.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexRunnerMap.scala
@@ -38,10 +38,10 @@ class IndexRunnerMap(centralCounter: Counter,
 
     val indexer = new SolrIndexDAO(newIndexDir.getParentFile.getParent, Config.excludeSensitiveValuesFor, Config.extraMiscFields)
 
-    var counter = 0
+    val counter = new AtomicLong(0)
     val start = System.currentTimeMillis
-    var startTime = System.currentTimeMillis
-    var finishTime = System.currentTimeMillis
+    val startTime = new AtomicLong(System.currentTimeMillis)
+    val finishTime = new AtomicLong(System.currentTimeMillis)
 
     val csvFileWriter = if (Config.exportIndexAsCsvPath.length > 0) {
       indexer.getCsvWriter()
@@ -121,7 +121,7 @@ class IndexRunnerMap(centralCounter: Counter,
     Config.persistenceManager.pageOverLocal("occ", (guid, map, _) => {
       t2Total.addAndGet(System.nanoTime() - t2)
 
-      counter += 1
+      val lastCounter = counter.incrementAndGet()
       //ignore the record if it has the guid that is the startKey this is because it will be indexed last by the previous thread.
       try {
         val uuid = map.getOrElse("uuid", "")
@@ -147,9 +147,9 @@ class IndexRunnerMap(centralCounter: Counter,
           }
       }
 
-      if (counter % pageSize * 10 == 0 && counter > 0) {
+      if (lastCounter % pageSize * 10 == 0 && lastCounter > 0) {
         centralCounter.addToCounter(pageSize)
-        finishTime = System.currentTimeMillis
+        finishTime.set(System.currentTimeMillis)
         centralCounter.printOutStatus(threadId, guid, "Indexer", startTimeFinal)
 
 
@@ -164,7 +164,7 @@ class IndexRunnerMap(centralCounter: Counter,
 
         if(Config.jmxDebugEnabled){
           JMX.updateIndexStatus(
-            centralCounter.counter,
+            centralCounter.counter.get(),
             centralCounter.getAverageRecsPerSec(startTimeFinal), //records per sec
             t2Total.get() / 1000000000, //cassandra time
             timing.get() / 1000000000, //processing time
@@ -180,7 +180,7 @@ class IndexRunnerMap(centralCounter: Counter,
         }
       }
 
-      startTime = System.currentTimeMillis
+      startTime.set(System.currentTimeMillis)
 
       t2 = System.nanoTime()
 
@@ -217,8 +217,8 @@ class IndexRunnerMap(centralCounter: Counter,
     //wait for threads to end
     threads.foreach(t => t.join())
 
-    finishTime = System.currentTimeMillis
-    logger.info("Total indexing time for this thread " + (finishTime - start).toFloat / 60000f + " minutes.")
+    finishTime.set(System.currentTimeMillis)
+    logger.info("Total indexing time for this thread " + (finishTime.get() - start).toFloat / 60000f + " minutes.")
 
     //close and merge the lucene index parts
     if (luceneIndexing != null && !singleWriter) {

--- a/src/main/scala/au/org/ala/biocache/tool/SampleLocalRecords.scala
+++ b/src/main/scala/au/org/ala/biocache/tool/SampleLocalRecords.scala
@@ -353,7 +353,7 @@ class SampleLocalRecords extends Counter {
           counterLoaded.incrementAndGet()
         }
         if (lastCounter % 1000 == 0) {
-          logger.info(s"[Loading sampling] Import of sample data $counter Last key $guid")
+          logger.info(s"[Loading sampling] Import of sample data $lastCounter Last key $guid")
         }
         true
       })
@@ -382,7 +382,7 @@ class SampleLocalRecords extends Counter {
           counterLoaded.incrementAndGet()
         }
         if (lastCounter % 1000 == 0) {
-          logger.info(s"[Loading sampling] Import of sample data $counter Last key $guid")
+          logger.info(s"[Loading sampling] Import of sample data $lastCounter Last key $guid")
         }
         true
       }, threads, Array("rowkey", dlat, dlon), localOnly = !allNodes)

--- a/src/main/scala/au/org/ala/biocache/tool/SampleLocalRecords.scala
+++ b/src/main/scala/au/org/ala/biocache/tool/SampleLocalRecords.scala
@@ -11,6 +11,7 @@ import au.org.ala.biocache.util.{Json, OptionParser, ZookeeperUtil}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters
+import java.util.concurrent.atomic.AtomicLong
 
 object SampleLocalRecords extends au.org.ala.biocache.cmd.Tool {
 
@@ -319,7 +320,7 @@ class SampleLocalRecords extends Counter {
     sample(workingDir, threads, keepFiles, loadOccOnly, sampleOnly, queue, rowkeys, layers, allNodes)
   }
 
-  def loadSamplingIntoOccurrences(threads: Int, rowkeys: Seq[String], allNodes: Boolean) : (Int, Int) = {
+  def loadSamplingIntoOccurrences(threads: Int, rowkeys: Seq[String], allNodes: Boolean) : (Long, Long) = {
     if (rowkeys.length > 0 && !rowkeys.iterator.next().isEmpty) {
       logger.info(s"Starting loading sampling for ${rowkeys.length} records")
     } else {
@@ -329,13 +330,13 @@ class SampleLocalRecords extends Counter {
     val dlon = "decimalLongitude" + Config.persistenceManager.fieldDelimiter + "p"
 
     if (rowkeys.length > 0 && !rowkeys.iterator.next().isEmpty) {
-      var counterLoaded = 0
+      val counterLoaded = new AtomicLong(0)
 
       Config.persistenceManager.selectRows(rowkeys, "occ", Seq("rowkey", dlat, dlon), (map) => {
         val lat = map.getOrElse(dlat, "")
         val lon = map.getOrElse(dlon, "")
         val guid = map.getOrElse("rowkey", "")
-        counter += 1
+        val lastCounter = counter.incrementAndGet()
         if (lat != "" && lon != "" && lat != null && lon != null && lat != "null" && lon != "null") {
           val point = LocationDAO.getSamplesForLatLon(lat, lon)
           if (!point.isEmpty) {
@@ -349,22 +350,22 @@ class SampleLocalRecords extends Counter {
           } else {
             logger.info(s"[Loading sampling] Missing sampled values for $guid, with $lat, $lon")
           }
-          counterLoaded += 1
+          counterLoaded.incrementAndGet()
         }
-        if (counter % 1000 == 0) {
+        if (lastCounter % 1000 == 0) {
           logger.info(s"[Loading sampling] Import of sample data $counter Last key $guid")
         }
         true
       })
       logger.info(s"[Loading sampling] Import of sample data complete. Records sampled:  $counter. Records with coordinates: $counterLoaded")
-      (counter,counterLoaded)
+      (counter.get(),counterLoaded.get())
     } else {
 
-      var counterLoaded = 0
+      val counterLoaded = new AtomicLong(0)
       Config.persistenceManager.asInstanceOf[Cassandra3PersistenceManager].pageOverLocalNotAsync("occ", (guid, map, _) => {
         val lat = map.getOrElse(dlat, "")
         val lon = map.getOrElse(dlon, "")
-        counter += 1
+        val lastCounter = counter.incrementAndGet()
         if (lat != "" && lon != "" && lat != null && lon != null && lat != "null" && lon != "null") {
           val point = LocationDAO.getSamplesForLatLon(lat, lon)
           if (!point.isEmpty) {
@@ -378,16 +379,16 @@ class SampleLocalRecords extends Counter {
           } else {
             logger.info(s"[Loading sampling] Missing sampled values for $guid, with $lat, $lon")
           }
-          counterLoaded += 1
+          counterLoaded.incrementAndGet()
         }
-        if (counter % 1000 == 0) {
+        if (lastCounter % 1000 == 0) {
           logger.info(s"[Loading sampling] Import of sample data $counter Last key $guid")
         }
         true
       }, threads, Array("rowkey", dlat, dlon), localOnly = !allNodes)
       logger.info(s"[Loading sampling] Import of sample data complete. Records sampled:  $counter. Records with coordinates: $counterLoaded")
 
-      (counter,counterLoaded)
+      (counter.get(),counterLoaded.get())
     }
   }
 }

--- a/src/main/scala/au/org/ala/biocache/util/CountAwareFacetConsumer.scala
+++ b/src/main/scala/au/org/ala/biocache/util/CountAwareFacetConsumer.scala
@@ -5,36 +5,58 @@ import scala.collection.mutable.ArrayBuffer
 import java.util.concurrent.BlockingQueue
 import org.slf4j.LoggerFactory
 
-class CountAwareFacetConsumer(q: BlockingQueue[String], id: Int, proc: Array[String] => Unit, countSize: Int = 0, minSize: Int = 1) extends Thread {
+class CountAwareFacetConsumer(q: BlockingQueue[String], id: Int, sentinel: String, proc: Array[String] => Unit, countSize: Int = 0, minSize: Int = 1) extends Thread {
   val logger = LoggerFactory.getLogger("CountAwareFacetConsumer")
-  var shouldStop = false
 
   override def run() {
     val buf = new ArrayBuffer[String]()
     var counter = 0
     var batchSize = 0
-    while (!shouldStop || q.size() > 0) {
-      try {
-        //wait 1 second before assuming that the queue is empty
-        val value = q.poll(1, java.util.concurrent.TimeUnit.SECONDS)
-        if (value != null) {
-          DuplicationDetection.logger.debug("Count Aware Consumer " + id + " is handling " + value)
-          val values = value.split("\t")
-          val count = Integer.parseInt(values(1))
-          if (count >= minSize) {
-            counter += count
-            batchSize += 1
-            buf += values(0)
-            if (counter >= countSize || batchSize == 200) {
-              val array = buf.toArray
-              buf.clear()
-              counter = 0
-              batchSize = 0
-              proc(array)
+    var finished = false
+    try {
+      while (!finished && !Thread.currentThread().isInterrupted()) {
+        try {
+          //wait 1 second before assuming that the queue is empty
+          val value = q.poll(1, java.util.concurrent.TimeUnit.SECONDS)
+          if (value == sentinel) {
+            if (logger.isDebugEnabled()) {
+              logger.debug("CountAwareFacetConsumer " + id + " is returning on sentinel")
+            }
+            finished = true
+          } else if (value != null) {
+            if (logger.isDebugEnabled()) {
+              logger.debug("Count Aware Consumer " + id + " is handling " + value)
+            }
+            val values = value.split("\t")
+            val count = Integer.parseInt(values(1))
+            if (count >= minSize) {
+              counter += count
+              batchSize += 1
+              buf += values(0)
+              if (counter >= countSize || batchSize == 200) {
+                val array = buf.toArray
+                buf.clear()
+                counter = 0
+                batchSize = 0
+                proc(array)
+              }
             }
           }
+        } catch {
+          case interrupted: InterruptedException => throw interrupted
+          case e: Exception => e.printStackTrace()
+        }
+      }
+    } finally {
+      try {
+        // process anything that was left in the buffer after the queue was emptied
+        val array = buf.toArray
+        buf.clear()
+        if (!array.isEmpty) {
+          proc(array)
         }
       } catch {
+        case interrupted: InterruptedException => throw interrupted
         case e: Exception => e.printStackTrace()
       }
     }

--- a/src/main/scala/au/org/ala/biocache/util/StringConsumer.scala
+++ b/src/main/scala/au/org/ala/biocache/util/StringConsumer.scala
@@ -3,29 +3,41 @@ package au.org.ala.biocache.util
 import java.util.concurrent.BlockingQueue
 import au.org.ala.biocache.tool.DuplicationDetection
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A generic threaded consumer that takes a string and calls the supplied proc
  */
-class StringConsumer(q: BlockingQueue[String], id: Int, proc: String => Unit) extends Thread {
+class StringConsumer(q: BlockingQueue[String], id: Int, sentinel: String, proc: String => Unit) extends Thread {
 
   protected val logger = LoggerFactory.getLogger("StringConsumer")
 
-  var shouldStop = false
-
   override def run() {
-    while (!shouldStop || q.size() > 0) {
+    var finished = false
+    while (!finished && !Thread.currentThread().isInterrupted()) {
       try {
-        //wait 1 second before assuming that the queue is empty
         val guid = q.poll(1, java.util.concurrent.TimeUnit.SECONDS)
-        if (guid != null) {
-          logger.debug("Guid Consumer " + id + " is handling " + guid)
+        if (guid == sentinel) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("StringConsumer " + id + " is returning on sentinel")
+          }
+          finished = true
+        } else if (guid != null) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("StringConsumer " + id + " is handling " + guid)
+          }
           proc(guid)
         }
       } catch {
+        case interrupted: InterruptedException => {
+          Thread.currentThread().interrupt()
+          throw interrupted
+        }
         case e: Exception => e.printStackTrace()
       }
     }
-    logger.debug("Stopping " + id)
+    if (logger.isDebugEnabled()) {
+      logger.debug("Stopping " + id)
+    }
   }
 }


### PR DESCRIPTION
Cannot rely on current counts to identify other potential data or biocache-store bugs

Also switches to using sentinels for StringConsumer to avoid hacky queue.empty semantics

Also adds thread based interruption to avoid having consumers sitting inactive after the VM has been interrupted.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>