### PR TITLE
Add docValues=true support in offline indexing

### DIFF
--- a/src/main/scala/au/org/ala/biocache/index/lucene/DocBuilder.java
+++ b/src/main/scala/au/org/ala/biocache/index/lucene/DocBuilder.java
@@ -259,14 +259,11 @@ public class DocBuilder {
         try {
             if (val instanceof IndexableField) {
                 ((Field) val).setBoost(1f);
-                doc.add(field, (Field) val);
+                List<IndexableField> list = new ArrayList<IndexableField>();
+                list.add((IndexableField) val);
+                doc.add(field, list);
             } else {
-
-                for (IndexableField f : field.getType().createFields(field, val, 1f)) {
-                    if (f != null) {
-                        doc.add(field, f);
-                    }
-                }
+                doc.add(field, field.getType().createFields(field, val, 1f));
             }
         } catch (Exception e) {
             logger.error("ERROR adding one field '" + currentId + "' '" + field.getName() + "' = '" + val.toString() + "' > " + e.getMessage());

--- a/src/main/scala/au/org/ala/biocache/index/lucene/RecycleDoc.java
+++ b/src/main/scala/au/org/ala/biocache/index/lucene/RecycleDoc.java
@@ -6,16 +6,14 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.BytesTermAttribute;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.spatial.prefix.CellToBytesRefIterator;
 import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
 import org.apache.lucene.spatial.prefix.tree.Cell;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.*;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.schema.*;
-import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.TextField;
 import org.apache.solr.util.DateMathParser;
 import org.apache.solr.util.SpatialUtils;
@@ -25,8 +23,9 @@ import org.locationtech.spatial4j.shape.Shape;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.text.SimpleDateFormat;
 import java.util.*;
+
+import static org.apache.solr.schema.NumberType.INTEGER;
 
 /**
  * A lucene document that recycles it's own fields.
@@ -36,7 +35,7 @@ public class RecycleDoc implements Iterable<IndexableField> {
 
     List<Boolean> fieldEnabled = new ArrayList<Boolean>();
     List<SchemaField> schemaFields = new ArrayList<SchemaField>();
-    List<IndexableField> fields = new ArrayList<IndexableField>();
+    List<List<IndexableField>> fields = new ArrayList<List<IndexableField>>();
 
     Map<String, List<Integer>> fieldOrder = new HashMap<String, List<Integer>>();
     int size = 0;
@@ -47,8 +46,8 @@ public class RecycleDoc implements Iterable<IndexableField> {
         this.schema = schema;
     }
 
-    public void add(SchemaField schemaField, IndexableField field) {
-        List<Integer> list = fieldOrder.computeIfAbsent(field.name(), k -> new ArrayList<Integer>());
+    public void add(SchemaField schemaField, List<IndexableField> field) {
+        List<Integer> list = fieldOrder.computeIfAbsent(schemaField.getName(), k -> new ArrayList<Integer>());
         list.add(fields.size());
 
         schemaFields.add(schemaField);
@@ -80,7 +79,8 @@ public class RecycleDoc implements Iterable<IndexableField> {
                 pos = 0;
                 for (Integer i : idx) {
                     if (fieldEnabled.get(i))
-                        s[pos++] = fields.get(i).stringValue();
+                        // when there are multiple fields associated with this schemaField, both string values are assumed to be identical
+                        s[pos++] = fields.get(i).get(0).stringValue();
                 }
                 return s;
             }
@@ -112,123 +112,122 @@ public class RecycleDoc implements Iterable<IndexableField> {
             int i = idx.get(count);
             SchemaField sf = schemaFields.get(i);
             org.apache.solr.schema.FieldType ft = sf.getType();
-            IndexableField f = fields.get(i);
+            for (IndexableField f : fields.get(i)) {
 
-            //Set all data types that are in use
-            try {
-                if (ft instanceof StrField) {
-                    try {
+                //Set all data types that are in use
+                try {
+                    if (ft instanceof StrField) {
                         if(isSortedDocValuesField(f)) {
                             setSortedDocValuesField(f, value);
                         } else {
                             ((Field) f).setStringValue(String.valueOf(value));
                         }
                         found = true;
-                    } catch (Exception e)  {
-                         logger.error("Problem setting field: " + f.name() + ", type: " + f.fieldType() + ", f: " + f.getClass().getCanonicalName() + ", error: "+ e.getMessage(), e);
-                    }
-                } else if (ft instanceof TrieDateField) {
-                    SimpleDateFormat dsf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-                    Date theDate = dsf.parse((String) value);
-                    ((Field) f).setLongValue(theDate.getTime());
-                    found = true;
-                } else if (ft instanceof TrieField) {
-                    switch (((TrieField) ft).getNumericType().ordinal()) {
-                        case 0:
-                            if(isSortedDocValuesField(f)) {
-                                setSortedDocValuesField(f, value);
-                            } else {
-                                Integer valueAsInt = value instanceof Number ? ((Number) value).intValue() : Integer.parseInt((String) value);
-                                ((Field) f).setIntValue(valueAsInt);
+                    } else if (ft instanceof TrieField) {
+                        if (f instanceof SortedSetDocValuesField) {
+                            //multivalued=true docvalues=true
+                            //TrieField creates LegacyFloatField (etc) first (fields.get(i).get(0))
+                            ((Field) f).setBytesValue(storedToIndexed(fields.get(i).get(0), (Number) value).get());
+
+                            found = true;
+                        } else if (f instanceof NumericDocValuesField) {
+                            //multivalued=false docvalues=true
+                            //TrieField creates LegacyFloatField (etc) first (fields.get(i).get(0))
+                            ((Field) f).setLongValue(formatNumericDocValuesFieldValue(fields.get(i).get(0), value));
+
+                            found = true;
+                        } else {
+                            switch (((TrieField) ft).getNumberType()) {
+                                case INTEGER:
+                                    Integer valueAsInt = value instanceof Number ? ((Number) value).intValue() : Integer.parseInt((String) value);
+                                    ((Field) f).setIntValue(valueAsInt);
+                                    found = true;
+                                    break;
+                                case LONG:
+                                    ((Field) f).setLongValue(value instanceof Number ? ((Number) value).longValue() : Long.parseLong((String) value));
+                                    found = true;
+                                    break;
+                                case FLOAT:
+                                    ((Field) f).setFloatValue(value instanceof Number ? ((Number) value).floatValue() : Float.parseFloat((String) value));
+                                    found = true;
+                                    break;
+                                case DOUBLE:
+                                    ((Field) f).setDoubleValue(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble((String) value));
+                                    found = true;
+                                    break;
+                                case DATE:
+                                    ((Field) f).setLongValue(value instanceof Date ? ((Date) value).getTime() : DateMathParser.parseMath(null, value.toString()).getTime());
+                                    found = true;
+                                    break;
+                                default:
+                                    org.apache.lucene.document.FieldType.LegacyNumericType type = ((TrieField) ft).getNumericType();
+                                    throw new RuntimeException("TrieField not recognised or supported. Ordinal value: " + type.ordinal() + ", " + type.getClass().getName());
                             }
-                            found = true;
-                            break;
-                        case 1:
-                            ((Field) f).setLongValue(value instanceof Number ? ((Number) value).longValue() : Long.parseLong((String) value));
-                            found = true;
-                            break;
-                        case 2:
-                            ((Field) f).setFloatValue(value instanceof Number ? ((Number) value).floatValue() : Float.parseFloat((String) value));
-                            found = true;
-                            break;
-                        case 3:
-                            ((Field) f).setDoubleValue(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble((String) value));
-                            found = true;
-                            break;
-                        case 4:
-                            ((Field) f).setLongValue(value instanceof Date ? ((Date) value).getTime() : DateMathParser.parseMath(null, value.toString()).getTime());
-                            found = true;
-                            break;
-                        default:
-                            org.apache.lucene.document.FieldType.LegacyNumericType type = ((TrieField) ft).getNumericType();
-                            throw new RuntimeException("TrieField not recognised or supported. Ordinal value: " + type.ordinal() + ", " + type.getClass().getName());
-                    }
-                } else if (ft instanceof TextField) {
-                    ((Field) f).setStringValue((String) value);
-                    found = true;
-                } else if (ft instanceof SpatialTermQueryPrefixTreeFieldType ||
-                        ft instanceof SpatialRecursivePrefixTreeFieldType) {
-
-                    PrefixTreeStrategy strategy = (ft instanceof SpatialTermQueryPrefixTreeFieldType) ?
-                            ((SpatialTermQueryPrefixTreeFieldType) ft).getStrategy(name) :
-                            ((SpatialRecursivePrefixTreeFieldType) ft).getStrategy(name);
-                    Double distErrPct = strategy.getDistErrPct();
-                    SpatialPrefixTree grid = strategy.getGrid();
-                    SpatialContext ctx = strategy.getSpatialContext();
-
-                    String str = String.valueOf(value);
-                    Shape shape;
-                    if (value instanceof Shape) {
-                        shape = (Shape) value;
-                    } else if (str.length() > 0 && Character.isLetter(str.charAt(0))) {
-                        shape = ((WKTReader) ctx.getFormats().getWktReader()).parse(str);
-                    } else {
-                        shape = SpatialUtils.parsePointSolrException(str, ctx);
-                    }
-
-                    if (shape != null) {
-                        if (sf.indexed()) {
-                            double distErr = SpatialArgs.calcDistanceFromErrPct(shape, distErrPct, ctx);
-                            int detailLevel = grid.getLevelForDistance(distErr);
-
-                            Iterator<Cell> cells = grid.getTreeCellIterator(shape, detailLevel);
-                            CellToBytesRefIterator cellToBytesRefIterator = new CellToBytesRefIterator();
-                            cellToBytesRefIterator.reset(cells);
-
-                            SpatialTokenStream tokenStream = new SpatialTokenStream();
-                            tokenStream.setBytesRefIterator(cellToBytesRefIterator);
-                            ((Field) f).setTokenStream(tokenStream);
-
-                            fieldEnabled.set(idx.get(count), true);
-
-                            //interate
-                            count++;
                         }
-
-                        if (sf.stored()) {
-                            //use next field if also indexed
-                            if (count < idx.size()) {
-                                i = idx.get(count);
-                                sf = schemaFields.get(i);
-                                ft = sf.getType();
-                                f = fields.get(i);
-                            }
-                            ((StoredField) f).setStringValue(String.valueOf(str));
-                        }
-
+                    } else if (ft instanceof TextField) {
+                        ((Field) f).setStringValue((String) value);
                         found = true;
+                    } else if (ft instanceof SpatialTermQueryPrefixTreeFieldType ||
+                            ft instanceof SpatialRecursivePrefixTreeFieldType) {
+
+                        PrefixTreeStrategy strategy = (ft instanceof SpatialTermQueryPrefixTreeFieldType) ?
+                                ((SpatialTermQueryPrefixTreeFieldType) ft).getStrategy(name) :
+                                ((SpatialRecursivePrefixTreeFieldType) ft).getStrategy(name);
+                        Double distErrPct = strategy.getDistErrPct();
+                        SpatialPrefixTree grid = strategy.getGrid();
+                        SpatialContext ctx = strategy.getSpatialContext();
+
+                        String str = String.valueOf(value);
+
+                        if (f instanceof StoredField) {
+                            ((StoredField) f).setStringValue(String.valueOf(str));
+
+                            found = true;
+                        } else {
+                            Shape shape;
+                            if (value instanceof Shape) {
+                                shape = (Shape) value;
+                            } else if (str.length() > 0 && Character.isLetter(str.charAt(0))) {
+                                shape = ((WKTReader) ctx.getFormats().getWktReader()).parse(str);
+                            } else {
+                                shape = SpatialUtils.parsePointSolrException(str, ctx);
+                            }
+
+                            if (shape != null) {
+                                double distErr = SpatialArgs.calcDistanceFromErrPct(shape, distErrPct, ctx);
+                                int detailLevel = grid.getLevelForDistance(distErr);
+
+                                Iterator<Cell> cells = grid.getTreeCellIterator(shape, detailLevel);
+                                CellToBytesRefIterator cellToBytesRefIterator = new CellToBytesRefIterator();
+                                cellToBytesRefIterator.reset(cells);
+
+                                SpatialTokenStream tokenStream = new SpatialTokenStream();
+                                tokenStream.setBytesRefIterator(cellToBytesRefIterator);
+                                ((Field) f).setTokenStream(tokenStream);
+
+                                fieldEnabled.set(idx.get(count), true);
+
+                                //interate
+                                count++;
+                            }
+
+                            if (sf.indexed()) {
+                                found = true;
+                            }
+                        }
+                    } else {
+                        logger.error("MISSING FIELD " + name + " = " + value.toString() + ", " + ft.getClass().getName());
                     }
-                } else {
-                    logger.error("MISSING FIELD " + name + " = " + value.toString() + ", " + ft.getClass().getName());
+                } catch (NumberFormatException e) {
+                    logger.error("NumberFormatException setting field " + name + " = " + value.toString() + ", " + ft.getClass().getName() + " : " + e.getMessage());
+                } catch (Exception e) {
+                    logger.error("FIELD EXCEPTION " + name + " = " + value.toString() + ", " + ft.getClass().getName() + " : " + e.getMessage(), e);
                 }
-            } catch (NumberFormatException e) {
-                logger.error("NumberFormatException setting field " + name + " = " + value.toString() + ", " + ft.getClass().getName() + " : " + e.getMessage());
-            } catch (Exception e) {
-                logger.error("FIELD EXCEPTION " + name + " = " + value.toString() + ", " + ft.getClass().getName() + " : " + e.getMessage(), e);
             }
-        }
-        if (found) {
-            fieldEnabled.set(idx.get(count), true);
+
+            if (found) {
+                fieldEnabled.set(i, true);
+            }
         }
         return found;
     }
@@ -288,6 +287,51 @@ public class RecycleDoc implements Iterable<IndexableField> {
         }
     }
 
+    // from org.apache.solr.schema.TrieField.createFields
+    private long formatNumericDocValuesFieldValue(IndexableField field, Object value) {
+        long bits;
+        if (!(field.numericValue() instanceof Integer) && !(field.numericValue() instanceof Long)) {
+            if (field.numericValue() instanceof Float) {
+                bits = (long) Float.floatToIntBits(((Number) value).floatValue());
+            } else {
+                bits = Double.doubleToLongBits(((Number) value).doubleValue());
+            }
+        } else {
+            bits = ((Number) value).longValue();
+        }
+
+        return bits;
+    }
+
+    // from org.apache.solr.schema.TrieField.storedToIndexed
+    private BytesRefBuilder storedToIndexed(IndexableField f, Number val) {
+        BytesRefBuilder bytes = new BytesRefBuilder();
+        if (val != null) {
+            switch (INTEGER) {
+                case INTEGER:
+                    LegacyNumericUtils.intToPrefixCoded(val.intValue(), 0, bytes);
+                    break;
+                case FLOAT:
+                    LegacyNumericUtils.intToPrefixCoded(NumericUtils.floatToSortableInt(val.floatValue()), 0, bytes);
+                    break;
+                case LONG:
+                case DATE:
+                    LegacyNumericUtils.longToPrefixCoded(val.longValue(), 0, bytes);
+                    break;
+                case DOUBLE:
+                    LegacyNumericUtils.longToPrefixCoded(NumericUtils.doubleToSortableLong(val.doubleValue()), 0, bytes);
+                    break;
+                default:
+                    throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Unknown type for trie field: " + f.name());
+            }
+
+        } else {
+            throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Invalid field contents: " + f.name());
+        }
+
+        return bytes;
+    }
+
     public Iterator<IndexableField> iterator() {
         //find first pos
         final int len = fieldEnabled.size();
@@ -297,16 +341,20 @@ public class RecycleDoc implements Iterable<IndexableField> {
 
         return new Iterator<IndexableField>() {
             int pos = start;
+            int offset = 0;
 
             public boolean hasNext() {
                 return pos < len;
             }
 
             public IndexableField next() {
-                IndexableField f = fields.get(pos);
+                IndexableField f = fields.get(pos).get(offset);
 
                 //find next
-                while (++pos < len && !fieldEnabled.get(pos)) ;
+                if (++offset >= fields.get(pos).size()) {
+                    offset = 0;
+                    while (++pos < len && !fieldEnabled.get(pos)) ;
+                }
 
                 return f;
             }


### PR DESCRIPTION
Hopeful that this will fix facet counts when using docValues=true.

e.g.
```
<field name="el899" type="tfloat" docValues="true" multiValued="false" indexed="false" stored="false"/>
<field name="cl22" type="string" docValues="true" multiValued="false" indexed="false" stored="false"/>
```