### PR TITLE
Fix for UnsupportedOperationException trying to add additional fields

### DIFF
--- a/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
@@ -1001,7 +1001,7 @@ class SolrIndexDAO @Inject()(@Named("solr.home") solrHome: String,
 
         writeOccIndexArrayToDoc(doc, guid, dataRow)
 
-        val fieldsAndType: Map[String, String] = Map[String, String]()
+        val fieldsAndType: scala.collection.mutable.Map[String, String] = scala.collection.mutable.Map[String, String]()
         if (userProvidedTypeMiscIndexProperties.nonEmpty || miscIndexProperties.nonEmpty || arrDefaultMiscFields.nonEmpty
           || Config.additionalFieldsToIndex.nonEmpty) {
 
@@ -1017,10 +1017,10 @@ class SolrIndexDAO @Inject()(@Named("solr.home") solrHome: String,
           Config.additionalFieldsToIndex.foreach(field =>
             if (!field.isEmpty) fieldsAndType.put(field.replaceAll("_[dsi(dt)]$", ""), field))
 
-          addJsonMapToDoc(doc, getArrayValue(columnOrder.miscPropertiesColumn, dataRow), fieldsAndType, null, true)
+          addJsonMapToDoc(doc, getArrayValue(columnOrder.miscPropertiesColumn, dataRow), fieldsAndType.toMap, null, true)
         } else {
           //when indexing everything always add miscPropertiesColumn values to the doc
-          addJsonMapToDoc(doc, getArrayValue(columnOrder.miscPropertiesColumn, dataRow), fieldsAndType, null, true)
+          addJsonMapToDoc(doc, getArrayValue(columnOrder.miscPropertiesColumn, dataRow), fieldsAndType.toMap, null, true)
         }
 
         addJsonArrayAssertionsToDoc(doc, getArrayValue(columnOrder.qualityAssertionColumn, dataRow))

--- a/src/test/resources/biocache-test-config.properties
+++ b/src/test/resources/biocache-test-config.properties
@@ -76,8 +76,10 @@ name.index.dir=/data/lucene/namematching
 exclude.sensitive.values=
 
 # Additional fields to index (used by biocache-store only)
-extra.misc.fields=
+extra.misc.fields=OriginalSeedQuantity_i
 #extraMiscFields=OriginalSeedQuantity_i,AdjustedSeedQuantity_i,CurrentSeedQuantity_i,ViabilitySummary_d
+
+additional.fields.to.index=habitat,raw_habitat
 
 # Max number of threads to use when processing a request
 endemic.query.maxthreads=30


### PR DESCRIPTION
I'm trying to indexing additional fields like `habitat` adding to `additional.fields.to.index` but I get a ` java.lang.UnsupportedOperationException` because Scala is using a inmutable map  for the fields in `SolrIndexDAO.scala` so does not have a put method.

The complete trace:
```
gbif18-cass3 2019-03-24 17:54:27,782 ERROR: [IndexRunner] - guid:f4953c71-1d1c-4120-81b5-a61a5370cb11, null
java.lang.UnsupportedOperationException
	at java.util.AbstractMap.put(AbstractMap.java:209)
	at au.org.ala.biocache.index.SolrIndexDAO$$anonfun$indexFromArray$3.apply(SolrIndexDAO.scala:1074)
	at au.org.ala.biocache.index.SolrIndexDAO$$anonfun$indexFromArray$3.apply(SolrIndexDAO.scala:1073)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:108)
	at au.org.ala.biocache.index.SolrIndexDAO.indexFromArray(SolrIndexDAO.scala:1073)
	at au.org.ala.biocache.index.IndexRunner$ProcessThread$1.run(IndexRunner.scala:164)
gbif18-cass3 2019-03-24 17:54:27,782 ERROR: [IndexRunner] - guid:019057b1-68e7-41f1
```

The tests fail if we add only new fields in the test config, but using a mutable map for the fields all tests past correctly.

I'm quite newbie here, so double check this PR ...