### PR TITLE
Bump jackson.version from 2.9.8 to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <org.springframework.version>4.3.24.RELEASE</org.springframework.version>
         <solr.version>6.6.5</solr.version>
         <jts.version>1.13</jts.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.10.1</jackson.version>
         <gt.version>11.1</gt.version>
         <cassandra.version>3.6.0</cassandra.version>
         <targetJdk>1.8</targetJdk>


### PR DESCRIPTION
Bumps `jackson.version` from 2.9.8 to 2.10.1.

Updates `jackson-core` from 2.9.8 to 2.10.1
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.8...jackson-core-2.10.1)

Updates `jackson-databind` from 2.9.8 to 2.10.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-annotations` from 2.9.8 to 2.10.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-module-scala_2.10` from 2.9.8 to 2.10.1
- [Release notes](https://github.com/FasterXML/jackson-module-scala/releases)
- [Changelog](https://github.com/FasterXML/jackson-module-scala/blob/master/release.sbt)
- [Commits](https://github.com/FasterXML/jackson-module-scala/compare/jackson-module-scala-2.9.8...jackson-module-scala-2.10.1)

Updates `jackson-bom` from 2.9.8 to 2.10.1
- [Release notes](https://github.com/FasterXML/jackson-bom/releases)
- [Commits](https://github.com/FasterXML/jackson-bom/compare/jackson-bom-2.9.8...jackson-bom-2.10.1)

Signed-off-by: dependabot[bot] <support@github.com>