### PR TITLE
Fix for #358

### DIFF
--- a/src/main/scala/au/org/ala/biocache/persistence/Cassandra3PersistenceManager.scala
+++ b/src/main/scala/au/org/ala/biocache/persistence/Cassandra3PersistenceManager.scala
@@ -66,6 +66,7 @@ class Cassandra3PersistenceManager  @Inject() (
   val map = new MapMaker().weakValues().makeMap[String, PreparedStatement]()
 
   val updateThreadPool = Executors.newFixedThreadPool(noOfUpdateThreads.toInt).asInstanceOf[ThreadPoolExecutor]
+  val executor = MoreExecutors.getExitingExecutorService(updateThreadPool)
 
   def getCacheSize = map.size()
 
@@ -437,7 +438,6 @@ class Cassandra3PersistenceManager  @Inject() (
   def putAsync(rowkey: String, entityName: String, keyValuePairs: Map[String, String], newRecord: Boolean, removeNullFields: Boolean) = {
 
     try {
-      val executor = MoreExecutors.getExitingExecutorService(updateThreadPool)
       val stmt: BoundStatement = createPutStatement(rowkey, entityName, keyValuePairs)
       val future = session.executeAsync(stmt)
       Futures.addCallback(future, new IngestCallback, executor)


### PR DESCRIPTION
A simple fix for #358. 

Using this I can end a `process-local-node` without performance degradation of 32M records.
```
biocache-store-1 2019-12-29 00:33:46,948 INFO : [Cassandra3PersistenceManager] - All threads have completed paging
biocache-store-1 2019-12-29 00:33:47,102 INFO : [ProcessLocalRecords] - Total records processed : 32027457 in 85081.65 seconds (or 236.33792 minutes) readCount=32027457 updateCount=32027457 updateFailCount=0
```