### PR TITLE
Include georeferencing in processed values

### DIFF
--- a/src/main/scala/au/org/ala/biocache/processor/LocationProcessor.scala
+++ b/src/main/scala/au/org/ala/biocache/processor/LocationProcessor.scala
@@ -80,6 +80,9 @@ class LocationProcessor extends Processor {
     //process state/country values if coordinates not determined
     processStateCountryValues(raw, processed, assertions)
 
+    //Process georeference information
+    processGeoreferenceValues(raw, processed, assertions)
+
     //create flag if no location info was supplied for this record
     checkLocationSupplied(raw, processed, assertions)
 
@@ -160,6 +163,24 @@ class LocationProcessor extends Processor {
       }
     }
   }
+
+  /**
+   * Process any georeference infomaation
+   *
+   * @param raw The original record
+   * @param processed Processed values
+   * @param assertions The current list of assertions
+   */
+  private def processGeoreferenceValues(raw: FullRecord, processed: FullRecord, assertions: ArrayBuffer[QualityAssertion]) {
+    // georeferencedDate is handled by the event prooessor
+    // processed.location.georeferencedDate = raw.location.georeferencedDate
+    processed.location.georeferencedBy = raw.location.georeferencedBy
+    processed.location.georeferenceProtocol = raw.location.georeferenceProtocol
+    processed.location.georeferenceRemarks = raw.location.georeferenceRemarks
+    processed.location.georeferenceSources = raw.location.georeferenceSources
+    processed.location.georeferenceVerificationStatus = raw.location.georeferenceVerificationStatus
+  }
+
 
   /**
     * Validation checks

--- a/src/test/scala/au/org/ala/biocache/ProcessLocationTest.scala
+++ b/src/test/scala/au/org/ala/biocache/ProcessLocationTest.scala
@@ -959,4 +959,37 @@ class ProcessLocationTest extends ConfigFunSuite with BeforeAndAfterAll {
       processed.location.decimalLongitude
     }
   }
+
+
+  test("georeferencing processing") {
+    var raw = new FullRecord
+    var processed = new FullRecord
+    raw.location.decimalLatitude="-29.04"
+    raw.location.decimalLongitude="167.95"
+    raw.location.georeferencedBy = "Minnie Bannister"
+    raw.location.georeferencedDate = "2020-06-12"
+    raw.location.georeferenceProtocol = "GPS"
+    raw.location.georeferenceRemarks = "This is a test"
+    raw.location.georeferenceSources = "The back of an envelope"
+    raw.location.georeferenceVerificationStatus = "unverified"
+    var qas = (new LocationProcessor).process("test", raw, processed)
+
+    expectResult(raw.location.georeferencedBy){
+      processed.location.georeferencedBy
+    }
+    assert(processed.location.georeferencedDate == null)
+    expectResult(raw.location.georeferenceProtocol){
+      processed.location.georeferenceProtocol
+    }
+    expectResult(raw.location.georeferenceRemarks){
+      processed.location.georeferenceRemarks
+    }
+    expectResult(raw.location.georeferenceSources){
+      processed.location.georeferenceSources
+    }
+    expectResult(raw.location.georeferenceVerificationStatus){
+      processed.location.georeferenceVerificationStatus
+    }
+  }
+
 }


### PR DESCRIPTION
Fix for #391 by explicitly copying georeferencing values across to processed.