### PR TITLE
Fix to include last assertion in indexing

### DIFF
--- a/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/index/SolrIndexDAO.scala
@@ -1299,8 +1299,11 @@ class SolrIndexDAO @Inject()(@Named("solr.home") solrHome: String,
     all.remove(AssertionCodes.PROCESSING_ERROR)
     all.remove(AssertionCodes.VERIFIED)
 
-    while (end > 2) {
+    while (end > 2 && i < jsonString.length()) {
       end = jsonString.indexOf('{', i + 1)
+      if (end < 0) { //last one, so there is no following '{'
+        end = jsonString.length()
+      }
 
       var codePos = jsonString.indexOf("\"code\":", i)
       var qaStatusPos = jsonString.indexOf("\"qaStatus\":", i)


### PR DESCRIPTION
The issue with the existing code is that is seems to skip the last entry in the JSON, because there is no '{' following this one. Possible fix in code.