### PR TITLE
fixed an issue about assertion_user_id

### DIFF
--- a/src/test/scala/au/org/ala/biocache/AssertionCodeTest.scala
+++ b/src/test/scala/au/org/ala/biocache/AssertionCodeTest.scala
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith
 import au.org.ala.biocache.model.{FullRecord, QualityAssertion, Versions}
 import au.org.ala.biocache.load.FullRecordMapper
 import au.org.ala.biocache.processor.RecordProcessor
+import au.org.ala.biocache.util.Json
 import au.org.ala.biocache.vocab.AssertionCodes
 import au.org.ala.biocache.vocab.AssertionStatus
 
@@ -13,6 +14,7 @@ class AssertionCodeTest extends ConfigFunSuite {
   val rowKey = "test1"
   val rowKey2 = "test2"
   val rowKey3 = "test3"
+  val rowKey4 = "test4"
   val uuid = "uuid"
   val occurrenceDAO = Config.occurrenceDAO
 
@@ -301,6 +303,60 @@ class AssertionCodeTest extends ConfigFunSuite {
     occurrenceDAO.deleteUserAssertion(rowKey3, qa1.uuid)
     expectResult(AssertionStatus.QA_NONE) {
       Integer.parseInt(pm.get(rowKey3, "occ", FullRecordMapper.userAssertionStatusColumn).get)
+    }
+  }
+
+  test("user assertion list") {
+    val processed = new FullRecord
+    processed.rowKey = uuid
+    occurrenceDAO.updateOccurrence(rowKey4, processed, None, Versions.PROCESSED)
+
+    // first qa added
+    val qa = QualityAssertion.apply(AssertionCodes.GEOSPATIAL_ISSUE, AssertionStatus.QA_UNCONFIRMED);
+    qa.userId = "hua091@csiro.au"
+    occurrenceDAO.addUserAssertion(rowKey4, qa)
+
+    var assertionList = Json.toListWithGeneric(Config.persistenceManager.get(rowKey4, "occ", FullRecordMapper.userQualityAssertionColumn).getOrElse(""), classOf[QualityAssertion]).asInstanceOf[List[QualityAssertion]]
+    expectResult(true) {
+      occurrenceDAO.getUserAssertions(rowKey4).size == 1 && assertionList.size == 1
+    }
+
+    // add second qa
+    val qa2 = QualityAssertion.apply(AssertionCodes.COORDINATE_HABITAT_MISMATCH, AssertionStatus.QA_UNCONFIRMED)
+    qa2.userId = "test@csiro.au"
+    occurrenceDAO.addUserAssertion(rowKey4, qa2)
+
+    assertionList = Json.toListWithGeneric(Config.persistenceManager.get(rowKey4, "occ", FullRecordMapper.userQualityAssertionColumn).getOrElse(""), classOf[QualityAssertion]).asInstanceOf[List[QualityAssertion]]
+    expectResult(true) {
+      occurrenceDAO.getUserAssertions(rowKey4).size == 2 && assertionList.size == 2
+    }
+
+    // a 50001 verification associated with 1st qa
+    val qa50001 = QualityAssertion.apply(AssertionCodes.VERIFIED, AssertionStatus.QA_OPEN_ISSUE);
+    qa50001.userId = "admin@csiro.au"
+    qa50001.relatedUuid = qa.uuid
+    occurrenceDAO.addUserAssertion(rowKey4, qa50001)
+
+    assertionList = Json.toListWithGeneric(Config.persistenceManager.get(rowKey4, "occ", FullRecordMapper.userQualityAssertionColumn).getOrElse(""), classOf[QualityAssertion]).asInstanceOf[List[QualityAssertion]]
+    expectResult(true) {
+      occurrenceDAO.getUserAssertions(rowKey4).size == 3 && assertionList.size == 2
+    }
+
+    occurrenceDAO.deleteUserAssertion(rowKey4, qa50001.uuid)
+    assertionList = Json.toListWithGeneric(Config.persistenceManager.get(rowKey4, "occ", FullRecordMapper.userQualityAssertionColumn).getOrElse(""), classOf[QualityAssertion]).asInstanceOf[List[QualityAssertion]]
+    expectResult(true) {
+      occurrenceDAO.getUserAssertions(rowKey4).size == 2 && assertionList.size == 2
+    }
+
+    // a 50002 verification associated with qa2
+    val qa50002 = QualityAssertion.apply(AssertionCodes.VERIFIED, AssertionStatus.QA_VERIFIED);
+    qa50002.userId = "admin1@csiro.au"
+    qa50002.relatedUuid = qa2.uuid
+    occurrenceDAO.addUserAssertion(rowKey4, qa50002)
+
+    assertionList = Json.toListWithGeneric(Config.persistenceManager.get(rowKey4, "occ", FullRecordMapper.userQualityAssertionColumn).getOrElse(""), classOf[QualityAssertion]).asInstanceOf[List[QualityAssertion]]
+    expectResult(true) {
+      occurrenceDAO.getUserAssertions(rowKey4).size == 3 && assertionList.size == 2
     }
   }
 


### PR DESCRIPTION
**Problems solved:**

This commit fixed 2 issues:

1. `updateAssertionStatus(rowKey, qualityAssertion, systemAssertions, userAssertions :+` **`qualityAssertion)`** this `qualityAssertion` is already in the `userAssertions` and added again into it (this change was originally made in https://github.com/AtlasOfLivingAustralia/biocache-store/commit/13a68ee2ef4c7b16ce118ce417aaa72648408160) . Making the same assertions have **2 copies** in the list. This is not necessary and causes issues.

In the below screen capture you can see **same assertion appears twice**

<img width="2175" alt="截屏2020-12-08 下午1 48 25" src="https://user-images.githubusercontent.com/61677987/101434853-730f7000-395f-11eb-9b70-fc067b37b10d.png">

2. Currently only outstanding user assertions (those not yet verified or verified as 50001) are saved into database and then used to generate `assertion_user_id`.

This commit added a new return value which contains all assertions users have made (what ever the status)  and this list is used to generate `'assertion_user_id'`. 
<br/>

**What's affected:**

When users access biocache-service/ws/occurrences/{occurrenceId} to get the detail of the occurrence record. the `userQualityAssertions` field is read out from the same database field so **with changes in this commit, this field now contains all the user assertions instead of outstanding user assertions. And the duplicate issue mentioned above is solved**.


